### PR TITLE
feat: Generate LLVM modules in RT driver

### DIFF
--- a/include/athena/backend/llvm/AthenaJIT.h
+++ b/include/athena/backend/llvm/AthenaJIT.h
@@ -52,7 +52,7 @@ class AthenaJIT {
     AthenaJIT(::llvm::orc::JITTargetMachineBuilder JTMB,
               ::llvm::DataLayout &&DL);
 
-    static ::llvm::Expected<std::unique_ptr<AthenaJIT>> create();
+    static std::unique_ptr<AthenaJIT> create();
     const ::llvm::DataLayout &getDataLayout() const {
         return mDataLayout;
     }

--- a/include/athena/backend/llvm/LLVMExecutor.h
+++ b/include/athena/backend/llvm/LLVMExecutor.h
@@ -14,6 +14,7 @@
 #define ATHENA_LLVMEXECUTOR_H
 
 #include <athena/backend/llvm/AthenaJIT.h>
+#include <athena/backend/llvm/runtime-driver/runtime-driver.h>
 #include <athena/core/Allocator.h>
 #include <athena/core/Executor.h>
 
@@ -31,6 +32,9 @@ class LLVMExecutor : public athena::core::Executor {
     std::unique_ptr<::llvm::Module> mMainModule;
     std::unique_ptr<core::Allocator> mAllocator;
     athena::core::Traversal mGraphTraversal;
+    std::unique_ptr<RuntimeDriver> mRuntimeDriver;
+
+    std::vector<std::unique_ptr<::llvm::Module>> mExistingModules;
 
     public:
     LLVMExecutor();
@@ -39,7 +43,7 @@ class LLVMExecutor : public athena::core::Executor {
      * execution
      * @param graph Graph to be executed
      */
-    void prepare(athena::core::Graph& graph) override;
+    void prepare(athena::core::Graph &graph) override;
     /**
      * Do actual computation
      */
@@ -48,14 +52,13 @@ class LLVMExecutor : public athena::core::Executor {
      *
      * @return Associated Allocator
      */
-    std::unique_ptr<core::Allocator>& getAllocator();
+    std::unique_ptr<core::Allocator> &getAllocator();
     /**
      * Set Allocator to be used
      * @param allocator User Allocator
      */
-    void setAllocator(std::unique_ptr<core::Allocator>& allocator);
+    void setAllocator(std::unique_ptr<core::Allocator> &allocator);
 };
-
 }  // namespace athena::backend::llvm
 
 #endif  // ATHENA_LLVMEXECUTOR_H

--- a/include/athena/backend/llvm/LLVMGeneratorFunctor.h
+++ b/include/athena/backend/llvm/LLVMGeneratorFunctor.h
@@ -44,9 +44,9 @@ template <>
 struct LLVMGeneratorFunctor<void> {
     LLVMGeneratorFunctor() = default;
     template <typename F>
-    LLVMGeneratorFunctor(F&& fun) : LLVMGeneratorFunctor(std::function(fun)){};
+    explicit LLVMGeneratorFunctor(F&& fun) : LLVMGeneratorFunctor(std::function(fun)){};
     template <typename... Args>
-    LLVMGeneratorFunctor(std::function<void(Args...)> fun)
+    explicit LLVMGeneratorFunctor(std::function<void(Args...)> fun)
         : mFunctor(std::move(fun)) {}
     template <typename... Args>
     void operator()(Args&&... args) {

--- a/include/athena/backend/llvm/device/Device.h
+++ b/include/athena/backend/llvm/device/Device.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 Alexander Batashev. All rights reserved.
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#ifndef ATHENA_DEVICE_H
+#define ATHENA_DEVICE_H
+
+namespace athena::backend::llvm {
+class Device {};
+}
+
+#endif //ATHENA_DEVICE_H

--- a/include/athena/backend/llvm/runtime-driver/runtime-driver.h
+++ b/include/athena/backend/llvm/runtime-driver/runtime-driver.h
@@ -33,11 +33,9 @@ private:
 
     std::vector<std::unique_ptr<::llvm::Module>> mModules;
 
-    void generateLLLVMIrBindings(
-        ::llvm::LLVMContext &ctx,
-        ::llvm::Module &module,
-        ::llvm::IRBuilder<> &builder
-    );
+    void generateLLVMIrBindings(::llvm::LLVMContext &ctx,
+                                ::llvm::Module &module,
+                                ::llvm::IRBuilder<> &builder);
 
     static ::llvm::ArrayRef<::llvm::Value*> getArgs(::llvm::Function *function);
 

--- a/include/athena/backend/llvm/runtime-driver/runtime-driver.h
+++ b/include/athena/backend/llvm/runtime-driver/runtime-driver.h
@@ -61,6 +61,8 @@ public:
     void unload();
     void reload(std::string_view nameLibrary);
     bool isLoaded() const;
+    
+    void prepareModules(::llvm::LLVMContext &ctx);
 
     void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c) {
         mFaddPointer(a, ca, b, cb, c);

--- a/include/athena/backend/llvm/runtime/add.h
+++ b/include/athena/backend/llvm/runtime/add.h
@@ -14,6 +14,7 @@
 #define ATHENA_ADD_H
 
 #include <athena/core/inner/Tensor.h>
+#include <athena/core/Allocator.h>
 #include <athena/backend/llvm/device/Device.h>
 
 
@@ -33,24 +34,12 @@ void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c);
 #endif
 
 template<typename T>
-void add(
+extern void add(
     athena::backend::llvm::Device *,
+    athena::core::Allocator *,
     athena::core::inner::Tensor *a,
-    athena::core::inner::Tensor *b
-);
-
-template <>
-void add<float>(
-    athena::backend::llvm::Device *,
-    athena::core::inner::Tensor *a,
-    athena::core::inner::Tensor *b
-);
-
-template <>
-void add<double>(
-    athena::backend::llvm::Device *,
-    athena::core::inner::Tensor *a,
-    athena::core::inner::Tensor *b
+    athena::core::inner::Tensor *b,
+    athena::core::inner::Tensor *c
 );
 
 #endif  // ATHENA_ADD_H

--- a/include/athena/backend/llvm/runtime/add.h
+++ b/include/athena/backend/llvm/runtime/add.h
@@ -13,8 +13,14 @@
 #ifndef ATHENA_ADD_H
 #define ATHENA_ADD_H
 
+#include <athena/core/inner/Tensor.h>
+#include <athena/backend/llvm/device/Device.h>
+
+
 #if __cplusplus
 #include <cstddef>
+
+
 extern "C" {
 #else
 #include <stddef.h>
@@ -25,5 +31,26 @@ void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c);
 #if __cplusplus
 }
 #endif
+
+template<typename T>
+void add(
+    athena::backend::llvm::Device *,
+    athena::core::inner::Tensor *a,
+    athena::core::inner::Tensor *b
+);
+
+template <>
+void add<float>(
+    athena::backend::llvm::Device *,
+    athena::core::inner::Tensor *a,
+    athena::core::inner::Tensor *b
+);
+
+template <>
+void add<double>(
+    athena::backend::llvm::Device *,
+    athena::core::inner::Tensor *a,
+    athena::core::inner::Tensor *b
+);
 
 #endif  // ATHENA_ADD_H

--- a/include/athena/backend/llvm/runtime/add.h
+++ b/include/athena/backend/llvm/runtime/add.h
@@ -13,33 +13,15 @@
 #ifndef ATHENA_ADD_H
 #define ATHENA_ADD_H
 
-#include <athena/core/inner/Tensor.h>
-#include <athena/core/Allocator.h>
 #include <athena/backend/llvm/device/Device.h>
+#include <athena/core/Allocator.h>
+#include <athena/core/inner/Tensor.h>
 
-
-#if __cplusplus
-#include <cstddef>
-
-
-extern "C" {
-#else
-#include <stddef.h>
-#endif
-
-void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c);
-
-#if __cplusplus
-}
-#endif
-
-template<typename T>
-extern void add(
-    athena::backend::llvm::Device *,
-    athena::core::Allocator *,
-    athena::core::inner::Tensor *a,
-    athena::core::inner::Tensor *b,
-    athena::core::inner::Tensor *c
-);
+template <typename T>
+extern void add(athena::backend::llvm::Device *,
+                athena::core::Allocator *,
+                athena::core::inner::Tensor *a,
+                athena::core::inner::Tensor *b,
+                athena::core::inner::Tensor *c);
 
 #endif  // ATHENA_ADD_H

--- a/include/athena/backend/llvm/runtime/allocate.h
+++ b/include/athena/backend/llvm/runtime/allocate.h
@@ -14,18 +14,13 @@
 #ifndef ATHENA_ALLOCATE_H
 #define ATHENA_ALLOCATE_H
 
-#if __cplusplus
-#include <cstddef>
-extern "C" {
-#else
-#include <stddef.h>
-#endif
+#include <athena/backend/llvm/device/Device.h>
+#include <athena/core/Allocator.h>
+#include <athena/core/inner/Tensor.h>
 
-void athena_allocate(void *allocator, void *tensor);
-size_t athena_get_fast_pointer(void *allocator, void *tensor);
-
-#if __cplusplus
-}
-#endif
+template <typename T>
+extern void allocate(athena::backend::llvm::Device *,
+                     athena::core::Allocator *,
+                     athena::core::inner::Tensor *a);
 
 #endif  // ATHENA_ALLOCATE_H

--- a/include/athena/backend/llvm/runtime/builtin.h
+++ b/include/athena/backend/llvm/runtime/builtin.h
@@ -12,6 +12,6 @@
 #ifndef ATHENA_BUILTIN_H
 #define ATHENA_BUILTIN_H
 
-#include "add.h"
+#include <athena/backend/llvm/runtime/add.h>
 
 #endif //ATHENA_BUILTIN_H

--- a/include/athena/backend/llvm/runtime/builtin.h
+++ b/include/athena/backend/llvm/runtime/builtin.h
@@ -13,5 +13,7 @@
 #define ATHENA_BUILTIN_H
 
 #include <athena/backend/llvm/runtime/add.h>
+#include <athena/backend/llvm/runtime/fill.h>
+#include <athena/backend/llvm/runtime/allocate.h>
 
-#endif //ATHENA_BUILTIN_H
+#endif  // ATHENA_BUILTIN_H

--- a/include/athena/backend/llvm/runtime/builtin.h
+++ b/include/athena/backend/llvm/runtime/builtin.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Alexander Batashev. All rights reserved.
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#ifndef ATHENA_BUILTIN_H
+#define ATHENA_BUILTIN_H
+
+#include "add.h"
+
+#endif //ATHENA_BUILTIN_H

--- a/include/athena/backend/llvm/runtime/fill.h
+++ b/include/athena/backend/llvm/runtime/fill.h
@@ -13,7 +13,14 @@
 
 #ifndef ATHENA_FILL_H
 #define ATHENA_FILL_H
-extern "C" {
-void athena_ffill(void *allocator, void *tensor, float f);
-};
+
+#include <athena/backend/llvm/device/Device.h>
+#include <athena/core/Allocator.h>
+#include <athena/core/inner/Tensor.h>
+
+template <typename T>
+extern void fill(athena::backend::llvm::Device *,
+                 athena::core::Allocator *,
+                 athena::core::inner::Tensor *a,
+                 T value);
 #endif  // ATHENA_FILL_H

--- a/src/backend/llvm/CMakeLists.txt
+++ b/src/backend/llvm/CMakeLists.txt
@@ -6,6 +6,9 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 set(WRAPPER_CPP ${CMAKE_CURRENT_BINARY_DIR}/wrapper.cpp)
 set(GENERATOR_CPP ${CMAKE_CURRENT_BINARY_DIR}/generator.cpp)
 
+file(WRITE ${WRAPPER_CPP} "")
+file(WRITE ${GENERATOR_CPP} "")
+
 add_custom_target(wrapper_cpp
         COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tablegen.py
         ${CMAKE_CURRENT_SOURCE_DIR}/builtins.td ${WRAPPER_CPP} wrapper

--- a/src/backend/llvm/CMakeLists.txt
+++ b/src/backend/llvm/CMakeLists.txt
@@ -3,10 +3,26 @@ find_package(LLVM CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+set(WRAPPER_CPP ${CMAKE_CURRENT_BINARY_DIR}/wrapper.cpp)
+set(GENERATOR_CPP ${CMAKE_CURRENT_BINARY_DIR}/generator.cpp)
+
+add_custom_target(wrapper_cpp
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tablegen.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/builtins.td ${WRAPPER_CPP} wrapper
+        )
+
+add_custom_target(generator_cpp
+        COMMAND ${PYTHON_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/tablegen.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/builtins.td ${GENERATOR_CPP} driver
+        )
+
 add_subdirectory(runtime-cpu)
 add_subdirectory(runtime-driver)
 
 file(GLOB codegen_src "codegen/*.cpp")
+
+find_package(PythonInterp REQUIRED)
 
 add_athena_library(backend-llvm STATIC
         LLVMExecutor.cpp

--- a/src/backend/llvm/LLVMGenerator.cpp
+++ b/src/backend/llvm/LLVMGenerator.cpp
@@ -23,14 +23,16 @@ namespace athena::backend::llvm {
 llvm::LLVMGenerator::LLVMGenerator(
     ::llvm::LLVMContext &ctx,
     const std::unique_ptr<::llvm::Module> &module,
-    core::Allocator &allocator)
-    : mModule(module),
+    core::Allocator &allocator,
+    std::vector<std::unique_ptr<::llvm::Module>> &existing)
+    : mGeneratedModule(module),
       mMainBlock(::llvm::BasicBlock::Create(
           ctx, "entry", module->getFunction("jitmain"))),
       mCurrentBlock(mMainBlock),
       mContext(ctx),
       mBuilder(::llvm::IRBuilder(mMainBlock)),
-      mAllocator(allocator) {
+      mAllocator(allocator),
+      mExistingModules(existing) {
     mBuilder.SetInsertPoint(mMainBlock);
     codegen::registerDefaultFunctors(this);
 }
@@ -41,10 +43,10 @@ llvm::LLVMGenerator::LLVMGenerator(
 
 ::llvm::Value *LLVMGenerator::generateGetFastPointer(core::inner::Tensor &t) {
     ::llvm::Function *calledFunction =
-        mModule->getFunction("athena_get_fast_pointer");
+        mGeneratedModule->getFunction("athena_get_fast_pointer");
 
     if (!calledFunction)
-        calledFunction = impl::create_get_fast_pointer_decl(mContext, *mModule);
+        calledFunction = impl::create_get_fast_pointer_decl(mContext, *mGeneratedModule);
 
     if (!calledFunction) {
         core::FatalError(1, "Unknown function referenced");
@@ -64,7 +66,7 @@ llvm::LLVMGenerator::LLVMGenerator(
 void LLVMGenerator::generateLoad(const core::AbstractLoader &loader,
                                  core::inner::Tensor &tensor) {
     ::llvm::Function *loadFunction =
-        mModule->getFunction(loader.getLoadCName());
+        mGeneratedModule->getFunction(loader.getLoadCName());
 
     if (!loadFunction) {
         std::vector<::llvm::Type *> args(3, ::llvm::Type::getInt64Ty(mContext));
@@ -73,7 +75,7 @@ void LLVMGenerator::generateLoad(const core::AbstractLoader &loader,
 
         loadFunction =
             ::llvm::Function::Create(FT, ::llvm::Function::ExternalLinkage,
-                                     loader.getLoadCName(), mModule.get());
+                                     loader.getLoadCName(), mGeneratedModule.get());
     }
 
     if (!loadFunction) {
@@ -94,23 +96,23 @@ void LLVMGenerator::generateLoad(const core::AbstractLoader &loader,
     mBuilder.CreateCall(loadFunction, ArgsV);
 }
 void LLVMGenerator::generateImpl(std::string &name, core::inner::Tensor &a) {
-    mFunctorsMap[name](mContext, *mModule, mBuilder, a);
+    mFunctorsMap[name](mContext, *mGeneratedModule, mBuilder, a);
 }
 void LLVMGenerator::generateImpl(std::string &name,
                                  core::inner::Tensor &a,
                                  void *&b) {
-    mFunctorsMap[name](mContext, *mModule, mBuilder, a, b);
+    mFunctorsMap[name](mContext, *mGeneratedModule, mBuilder, a, b);
 }
 void LLVMGenerator::generateImpl(std::string &name,
                                  core::inner::Tensor &a,
                                  core::inner::Tensor &b) {
-    mFunctorsMap[name](mContext, *mModule, mBuilder, a, b);
+    mFunctorsMap[name](mContext, *mGeneratedModule, mBuilder, a, b);
 }
 void LLVMGenerator::generateImpl(std::string &name,
                                  core::inner::Tensor &a,
                                  core::inner::Tensor &b,
                                  core::inner::Tensor &c) {
-    mFunctorsMap[name](mContext, *mModule, mBuilder, a, b, c);
+    mFunctorsMap[name](mContext, *mGeneratedModule, mBuilder, a, b, c);
 }
 void LLVMGenerator::openNode(std::string_view name) {
 #ifdef DEBUG
@@ -120,7 +122,7 @@ void LLVMGenerator::openNode(std::string_view name) {
         ::llvm::FunctionType::get(::llvm::Type::getVoidTy(mContext), false);
     auto nodeFunction =
         ::llvm::Function::Create(FT, ::llvm::Function::ExternalLinkage,
-                                 "node_" + std::string(name), *mModule);
+                                 "node_" + std::string(name), *mGeneratedModule);
 
     mBuilder.CreateCall(nodeFunction);
 

--- a/src/backend/llvm/LLVMGenerator.cpp
+++ b/src/backend/llvm/LLVMGenerator.cpp
@@ -41,28 +41,6 @@ llvm::LLVMGenerator::LLVMGenerator(
     return mBuilder;
 }
 
-::llvm::Value *LLVMGenerator::generateGetFastPointer(core::inner::Tensor &t) {
-    ::llvm::Function *calledFunction =
-        mGeneratedModule->getFunction("athena_get_fast_pointer");
-
-    if (!calledFunction)
-        calledFunction = impl::create_get_fast_pointer_decl(mContext, *mGeneratedModule);
-
-    if (!calledFunction) {
-        core::FatalError(1, "Unknown function referenced");
-    }
-
-    std::vector<::llvm::Value *> ArgsV;
-    ::llvm::Constant *allocatorConst = ::llvm::ConstantInt::get(
-        ::llvm::Type::getInt64Ty(mContext), (size_t)(&mAllocator));
-    ArgsV.push_back(allocatorConst);
-    ::llvm::Constant *tensorConst = ::llvm::ConstantInt::get(
-        ::llvm::Type::getInt64Ty(mContext), reinterpret_cast<size_t>(&t));
-    ArgsV.push_back(tensorConst);
-    auto callInst = mBuilder.CreateCall(calledFunction, ArgsV);
-    return callInst;
-}
-
 void LLVMGenerator::generateLoad(const core::AbstractLoader &loader,
                                  core::inner::Tensor &tensor) {
     ::llvm::Function *loadFunction =

--- a/src/backend/llvm/builtins.td
+++ b/src/backend/llvm/builtins.td
@@ -1,1 +1,3 @@
 add : Tensor*, Tensor*, Tensor*
+fill : Tensor*, gentype
+allocate : Tensor* : void

--- a/src/backend/llvm/builtins.td
+++ b/src/backend/llvm/builtins.td
@@ -1,1 +1,1 @@
-add : Tensor*, Tensor*
+add : Tensor*, Tensor*, Tensor*

--- a/src/backend/llvm/builtins.td
+++ b/src/backend/llvm/builtins.td
@@ -1,0 +1,1 @@
+add : Tensor*, Tensor*

--- a/src/backend/llvm/codegen/add.cpp
+++ b/src/backend/llvm/codegen/add.cpp
@@ -17,18 +17,6 @@
 
 namespace athena::backend::llvm::codegen {
 
-::llvm::Function *create_fadd_decl(::llvm::LLVMContext &ctx,
-                                   ::llvm::Module &module) {
-    std::vector<::llvm::Type *> args(5, ::llvm::Type::getInt64Ty(ctx));
-    ::llvm::FunctionType *FT =
-        ::llvm::FunctionType::get(::llvm::Type::getVoidTy(ctx), args, false);
-
-    ::llvm::Function *F = ::llvm::Function::Create(
-        FT, ::llvm::Function::ExternalLinkage, "athena_fadd", &module);
-
-    return F;
-}
-
 void registerAdd(LLVMGenerator *generator) {
     std::function<void(::llvm::LLVMContext &, ::llvm::Module &,
                        ::llvm::IRBuilder<> &, core::inner::Tensor &,
@@ -38,10 +26,7 @@ void registerAdd(LLVMGenerator *generator) {
                         core::inner::Tensor &b, core::inner::Tensor &c) {
             // todo handle different data types
 
-
             ::llvm::Function *calledFunction = generator->findLLVMFunction("athn_add_f");
-
-//            if (!calledFunction) calledFunction = create_fadd_decl(ctx, module);
 
             if (!calledFunction) {
                 core::FatalError(1, "Unknown function referenced");

--- a/src/backend/llvm/codegen/add.cpp
+++ b/src/backend/llvm/codegen/add.cpp
@@ -38,10 +38,10 @@ void registerAdd(LLVMGenerator *generator) {
                         core::inner::Tensor &b, core::inner::Tensor &c) {
             // todo handle different data types
 
-            ::llvm::Function *calledFunction =
-                module.getFunction("athena_fadd");
 
-            if (!calledFunction) calledFunction = create_fadd_decl(ctx, module);
+            ::llvm::Function *calledFunction = generator->findLLVMFunction("athn_add_f");
+
+//            if (!calledFunction) calledFunction = create_fadd_decl(ctx, module);
 
             if (!calledFunction) {
                 core::FatalError(1, "Unknown function referenced");
@@ -51,15 +51,23 @@ void registerAdd(LLVMGenerator *generator) {
 
             std::vector<::llvm::Value *> ArgsV;
 
-            ArgsV.push_back(generator->generateGetFastPointer(a));
-            ::llvm::Constant *aSizeConst = ::llvm::ConstantInt::get(
-                ::llvm::Type::getInt64Ty(ctx), a.getShapeView().getTotalSize());
-            ArgsV.push_back(aSizeConst);
-            ArgsV.push_back(generator->generateGetFastPointer(b));
-            ::llvm::Constant *bSizeConst = ::llvm::ConstantInt::get(
-                ::llvm::Type::getInt64Ty(ctx), b.getShapeView().getTotalSize());
-            ArgsV.push_back(bSizeConst);
-            ArgsV.push_back(generator->generateGetFastPointer(c));
+            ::llvm::Constant *device = ::llvm::ConstantInt::get(
+                ::llvm::Type::getInt64Ty(ctx),
+                reinterpret_cast<size_t>(generator->getPreferredDevice("add")));
+            ArgsV.push_back(device);
+            ::llvm::Constant *allocator = ::llvm::ConstantInt::get(
+                ::llvm::Type::getInt64Ty(ctx),
+                reinterpret_cast<size_t>(&generator->getAllocator()));
+            ArgsV.push_back(allocator);
+            ::llvm::Constant *aTensor = ::llvm::ConstantInt::get(
+                ::llvm::Type::getInt64Ty(ctx), reinterpret_cast<size_t>(&a));
+            ArgsV.push_back(aTensor);
+            ::llvm::Constant *bTensor = ::llvm::ConstantInt::get(
+                ::llvm::Type::getInt64Ty(ctx), reinterpret_cast<size_t>(&b));
+            ArgsV.push_back(bTensor);
+            ::llvm::Constant *cTensor = ::llvm::ConstantInt::get(
+                ::llvm::Type::getInt64Ty(ctx), reinterpret_cast<size_t>(&c));
+            ArgsV.push_back(cTensor);
             builder.CreateCall(calledFunction, ArgsV);
         };
 

--- a/src/backend/llvm/codegen/fill.cpp
+++ b/src/backend/llvm/codegen/fill.cpp
@@ -15,19 +15,6 @@
 
 namespace athena::backend::llvm::codegen {
 
-::llvm::Function *create_ffill_decl(::llvm::LLVMContext &ctx,
-                                    ::llvm::Module &module) {
-    std::vector<::llvm::Type *> args(2, ::llvm::Type::getInt64Ty(ctx));
-    args.push_back(::llvm::Type::getFloatTy(ctx));
-    ::llvm::FunctionType *FT =
-        ::llvm::FunctionType::get(::llvm::Type::getVoidTy(ctx), args, false);
-
-    ::llvm::Function *F = ::llvm::Function::Create(
-        FT, ::llvm::Function::ExternalLinkage, "athena_ffill", &module);
-
-    return F;
-}
-
 void registerFill(LLVMGenerator *generator) {
     std::function<void(::llvm::LLVMContext &, ::llvm::Module &,
                        ::llvm::IRBuilder<> &, core::inner::Tensor &, void *&)>
@@ -37,16 +24,17 @@ void registerFill(LLVMGenerator *generator) {
             // todo handle different data types
 
             ::llvm::Function *calledFunction =
-                module.getFunction("athena_ffill");
-
-            if (!calledFunction)
-                calledFunction = create_ffill_decl(ctx, module);
+                generator->findLLVMFunction("athn_fill_f");
 
             if (!calledFunction) {
                 core::FatalError(1, "Unknown function referenced");
             }
 
             std::vector<::llvm::Value *> ArgsV;
+            ::llvm::Constant *device = ::llvm::ConstantInt::get(
+                ::llvm::Type::getInt64Ty(ctx),
+                reinterpret_cast<size_t>(generator->getPreferredDevice("fill")));
+            ArgsV.push_back(device);
             ::llvm::Constant *allocatorConst =
                 ::llvm::ConstantInt::get(::llvm::Type::getInt64Ty(ctx),
                                          (size_t)(&generator->getAllocator()));

--- a/src/backend/llvm/runtime-cpu/CMakeLists.txt
+++ b/src/backend/llvm/runtime-cpu/CMakeLists.txt
@@ -48,7 +48,12 @@ endfunction(getblis)
 option(FORCE_BLIS "Require library to use BLIS" OFF)
 option(FORCE_ULAS "Require library to use uBLAS" OFF)
 
-add_athena_library(runtime-llvm-cpu SHARED add.cpp allocate.cpp fill.cpp)
+add_athena_library(runtime-llvm-cpu SHARED
+        add.cpp
+        allocate.cpp
+        fill.cpp
+        ${WRAPPER_CPP})
+add_dependencies(runtime-llvm-cpu wrapper_cpp)
 
 if (APPLE)
     set_property(TARGET runtime-llvm-cpu APPEND_STRING PROPERTY LINK_FLAGS " -undefined dynamic_lookup")

--- a/src/backend/llvm/runtime-cpu/add.cpp
+++ b/src/backend/llvm/runtime-cpu/add.cpp
@@ -14,11 +14,11 @@
 #include <athena/backend/llvm/runtime/add.h>
 #include <athena/backend/llvm/device/Device.h>
 #include <athena/core/inner/Tensor.h>
-
-#include <iostream>
+#include <athena/core/Allocator.h>
 
 using namespace athena::backend::llvm;
 using namespace athena::core::inner;
+using namespace athena::core;
 
 void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c) {
     auto *af = static_cast<float *>(a);
@@ -31,6 +31,29 @@ void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c) {
 }
 
 template <typename T>
-void add(Device *, Tensor *a, Tensor *b) {
+void add(Device *, Allocator* allocator, Tensor *a, Tensor *b, Tensor *c) {
 
+    auto *af = reinterpret_cast<T*>(allocator->getRAMPointer(*a));
+    auto *bf = reinterpret_cast<T*>(allocator->getRAMPointer(*b));
+    auto *cf = reinterpret_cast<T*>(allocator->getRAMPointer(*c));
+
+    for (size_t i = 0; i < c->getShape().getTotalSize(); i++) {
+        cf[i] = af[i] + bf[i];
+    }
 }
+
+template void add<float>(
+    athena::backend::llvm::Device *,
+    athena::core::Allocator *,
+    athena::core::inner::Tensor *a,
+    athena::core::inner::Tensor *b,
+    athena::core::inner::Tensor *c
+);
+
+template void add<double>(
+    athena::backend::llvm::Device *,
+    athena::core::Allocator *,
+    athena::core::inner::Tensor *a,
+    athena::core::inner::Tensor *b,
+    athena::core::inner::Tensor *c
+);

--- a/src/backend/llvm/runtime-cpu/add.cpp
+++ b/src/backend/llvm/runtime-cpu/add.cpp
@@ -11,49 +11,34 @@
  * the License.
  */
 
-#include <athena/backend/llvm/runtime/add.h>
 #include <athena/backend/llvm/device/Device.h>
-#include <athena/core/inner/Tensor.h>
+#include <athena/backend/llvm/runtime/add.h>
 #include <athena/core/Allocator.h>
+#include <athena/core/inner/Tensor.h>
 
 using namespace athena::backend::llvm;
 using namespace athena::core::inner;
 using namespace athena::core;
 
-void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c) {
-    auto *af = static_cast<float *>(a);
-    auto *bf = static_cast<float *>(b);
-    auto *cf = static_cast<float *>(c);
-
-    for (size_t i = 0; i < ca; i++) {
-        cf[i] = af[i] + bf[i];
-    }
-}
-
 template <typename T>
-void add(Device *, Allocator* allocator, Tensor *a, Tensor *b, Tensor *c) {
-
-    auto *af = reinterpret_cast<T*>(allocator->getRAMPointer(*a));
-    auto *bf = reinterpret_cast<T*>(allocator->getRAMPointer(*b));
-    auto *cf = reinterpret_cast<T*>(allocator->getRAMPointer(*c));
+void add(Device *, Allocator *allocator, Tensor *a, Tensor *b, Tensor *c) {
+    auto *af = reinterpret_cast<T *>(allocator->getRAMPointer(*a));
+    auto *bf = reinterpret_cast<T *>(allocator->getRAMPointer(*b));
+    auto *cf = reinterpret_cast<T *>(allocator->getRAMPointer(*c));
 
     for (size_t i = 0; i < c->getShape().getTotalSize(); i++) {
         cf[i] = af[i] + bf[i];
     }
 }
 
-template void add<float>(
-    athena::backend::llvm::Device *,
-    athena::core::Allocator *,
-    athena::core::inner::Tensor *a,
-    athena::core::inner::Tensor *b,
-    athena::core::inner::Tensor *c
-);
+template void add<float>(athena::backend::llvm::Device *,
+                         athena::core::Allocator *,
+                         athena::core::inner::Tensor *a,
+                         athena::core::inner::Tensor *b,
+                         athena::core::inner::Tensor *c);
 
-template void add<double>(
-    athena::backend::llvm::Device *,
-    athena::core::Allocator *,
-    athena::core::inner::Tensor *a,
-    athena::core::inner::Tensor *b,
-    athena::core::inner::Tensor *c
-);
+template void add<double>(athena::backend::llvm::Device *,
+                          athena::core::Allocator *,
+                          athena::core::inner::Tensor *a,
+                          athena::core::inner::Tensor *b,
+                          athena::core::inner::Tensor *c);

--- a/src/backend/llvm/runtime-cpu/add.cpp
+++ b/src/backend/llvm/runtime-cpu/add.cpp
@@ -12,8 +12,13 @@
  */
 
 #include <athena/backend/llvm/runtime/add.h>
+#include <athena/backend/llvm/device/Device.h>
+#include <athena/core/inner/Tensor.h>
 
 #include <iostream>
+
+using namespace athena::backend::llvm;
+using namespace athena::core::inner;
 
 void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c) {
     auto *af = static_cast<float *>(a);
@@ -23,4 +28,9 @@ void athena_fadd(void *a, size_t ca, void *b, size_t cb, void *c) {
     for (size_t i = 0; i < ca; i++) {
         cf[i] = af[i] + bf[i];
     }
+}
+
+template <typename T>
+void add(Device *, Tensor *a, Tensor *b) {
+
 }

--- a/src/backend/llvm/runtime-cpu/allocate.cpp
+++ b/src/backend/llvm/runtime-cpu/allocate.cpp
@@ -15,18 +15,15 @@
 #include <athena/core/Allocator.h>
 #include <athena/core/inner/Tensor.h>
 
-extern "C" {
-void athena_allocate(void *a, void *t) {
-    auto pAllocator = reinterpret_cast<athena::core::Allocator *>(a);
-    auto pTensor = reinterpret_cast<athena::core::inner::Tensor *>(t);
+using namespace athena::backend::llvm;
+using namespace athena::core::inner;
+using namespace athena::core;
 
-    pAllocator->allocate(*pTensor);
+template <typename T>
+void allocate(Device *, Allocator *allocator, Tensor *a) {
+    allocator->allocate(*a);
 }
 
-size_t athena_get_fast_pointer(void *a, void *t) {
-    auto pAllocator = reinterpret_cast<athena::core::Allocator *>(a);
-    auto pTensor = reinterpret_cast<athena::core::inner::Tensor *>(t);
-
-    return pAllocator->getFastPointer(*pTensor);
-}
-}
+template void allocate<void>(athena::backend::llvm::Device *,
+                         athena::core::Allocator *,
+                         athena::core::inner::Tensor *a);

--- a/src/backend/llvm/runtime-cpu/fill.cpp
+++ b/src/backend/llvm/runtime-cpu/fill.cpp
@@ -11,19 +11,31 @@
  * the License.
  */
 
+#include <athena/backend/llvm/device/Device.h>
+#include <athena/backend/llvm/runtime/add.h>
 #include <athena/backend/llvm/runtime/fill.h>
 #include <athena/core/Allocator.h>
 #include <athena/core/inner/Tensor.h>
 
-extern "C" {
-void athena_ffill(void *allocator, void *tensor, float f) {
-    auto *pAllocator = reinterpret_cast<athena::core::Allocator *>(allocator);
-    auto *pTensor = reinterpret_cast<athena::core::inner::Tensor *>(tensor);
+using namespace athena::backend::llvm;
+using namespace athena::core::inner;
+using namespace athena::core;
 
-    auto *mem = reinterpret_cast<float *>(pAllocator->getRAMPointer(*pTensor));
+template <typename T>
+void fill(Device *, Allocator *allocator, Tensor *a, T value) {
+    auto *memory = reinterpret_cast<T *>(allocator->getRAMPointer(*a));
 
-    for (size_t i = 0; i < pTensor->getShapeView().getTotalSize(); i++) {
-        mem[i] = f;
+    for (size_t i = 0; i < a->getShape().getTotalSize(); i++) {
+        memory[i] = value;
     }
 }
-}
+
+template void fill<float>(athena::backend::llvm::Device *,
+                          athena::core::Allocator *,
+                          athena::core::inner::Tensor *a,
+                          float value);
+
+template void fill<double>(athena::backend::llvm::Device *,
+                           athena::core::Allocator *,
+                           athena::core::inner::Tensor *a,
+                           double value);

--- a/src/backend/llvm/runtime-driver/CMakeLists.txt
+++ b/src/backend/llvm/runtime-driver/CMakeLists.txt
@@ -1,6 +1,14 @@
-add_athena_library(runtime-driver STATIC runtime-driver.cpp)
-target_link_libraries(runtime-driver athena-core)
-add_dependencies(runtime-driver runtime-llvm-cpu)
+add_athena_library(runtime-driver STATIC runtime-driver.cpp ${GENERATOR_CPP})
+target_link_libraries(runtime-driver PRIVATE athena-core)
+add_dependencies(runtime-driver runtime-llvm-cpu generator_cpp)
+
+target_include_directories(runtime-driver PRIVATE ${LLVM_INCLUDE_DIRS})
+target_compile_definitions(runtime-driver PRIVATE ${LLVM_DEFINITIONS})
+
+llvm_map_components_to_libnames(llvm_libs core irreader support transformutils)
+
+target_link_libraries(runtime-driver PRIVATE ${llvm_libs})
+
 if (UNIX AND NOT APPLE)
     target_link_libraries(runtime-driver dl.so)
 #else ()

--- a/src/backend/llvm/runtime-driver/CMakeLists.txt
+++ b/src/backend/llvm/runtime-driver/CMakeLists.txt
@@ -5,7 +5,7 @@ add_dependencies(runtime-driver runtime-llvm-cpu generator_cpp)
 target_include_directories(runtime-driver PRIVATE ${LLVM_INCLUDE_DIRS})
 target_compile_definitions(runtime-driver PRIVATE ${LLVM_DEFINITIONS})
 
-llvm_map_components_to_libnames(llvm_libs core irreader support transformutils)
+llvm_map_components_to_libnames(llvm_libs all)
 
 target_link_libraries(runtime-driver PRIVATE ${llvm_libs})
 

--- a/src/backend/llvm/runtime-driver/runtime-driver.cpp
+++ b/src/backend/llvm/runtime-driver/runtime-driver.cpp
@@ -75,7 +75,7 @@ bool RuntimeDriver::isLoaded() const {
 void RuntimeDriver::prepareModules() {
     auto newModule = std::make_unique<::llvm::Module>("runtime", mContext);
     ::llvm::IRBuilder<> builder(mContext);
-    generateLLLVMIrBindings(mContext, *newModule, builder);
+    generateLLVMIrBindings(mContext, *newModule, builder);
 #ifdef DEBUG
     bool brokenDebugInfo = false;
     std::string str;

--- a/src/backend/llvm/runtime-driver/runtime-driver.cpp
+++ b/src/backend/llvm/runtime-driver/runtime-driver.cpp
@@ -13,7 +13,7 @@
 
 #include <athena/backend/llvm/runtime-driver/runtime-driver.h>
 
-namespace athena::backend {
+namespace athena::backend::llvm {
 
 RuntimeDriver kRuntimeDriver;
 
@@ -75,19 +75,28 @@ void RuntimeDriver::reload(std::string_view nameLibrary) {
 bool RuntimeDriver::isLoaded() const {
     return mLibraryHandle != nullptr;
 }
+::llvm::ArrayRef<::llvm::Value *> RuntimeDriver::getArgs(::llvm::Function *function) {
+    std::vector<::llvm::Value *> argValues;
+
+    for (auto &arg : function->args()) {
+        argValues.push_back(arg.getValueName()->second);
+    }
+
+    return argValues;
+}
 }  // namespace athena::backend
 
 extern "C" {
-void athena_fadd(void* a, size_t ca, void* b, size_t cb, void* c) {
-    athena::backend::kRuntimeDriver.athena_fadd(a, ca, b, cb, c);
-}
-void athena_allocate(void* a, void* t) {
-    athena::backend::kRuntimeDriver.athena_allocate(a, t);
-}
-void* athena_get_fast_pointer(void* a, void* t) {
-    return athena::backend::kRuntimeDriver.athena_get_fast_pointer(a, t);
-}
-void athena_ffill(void* allocator, void* tensor, float f) {
-    athena::backend::kRuntimeDriver.athena_ffill(allocator, tensor, f);
-}
+//void athena_fadd(void* a, size_t ca, void* b, size_t cb, void* c) {
+//    athena::backend::kRuntimeDriver.athena_fadd(a, ca, b, cb, c);
+//}
+//void athena_allocate(void* a, void* t) {
+//    athena::backend::kRuntimeDriver.athena_allocate(a, t);
+//}
+//void* athena_get_fast_pointer(void* a, void* t) {
+//    return athena::backend::kRuntimeDriver.athena_get_fast_pointer(a, t);
+//}
+//void athena_ffill(void* allocator, void* tensor, float f) {
+//    athena::backend::kRuntimeDriver.athena_ffill(allocator, tensor, f);
+//}
 }

--- a/src/backend/llvm/runtime-driver/runtime-driver.cpp
+++ b/src/backend/llvm/runtime-driver/runtime-driver.cpp
@@ -12,6 +12,8 @@
  */
 
 #include <athena/backend/llvm/runtime-driver/runtime-driver.h>
+#include <llvm/Support/Debug.h>
+
 
 namespace athena::backend::llvm {
 
@@ -79,10 +81,17 @@ bool RuntimeDriver::isLoaded() const {
     std::vector<::llvm::Value *> argValues;
 
     for (auto &arg : function->args()) {
-        argValues.push_back(arg.getValueName()->second);
+        argValues.push_back(&arg);
     }
 
     return argValues;
+}
+void RuntimeDriver::prepareModules(::llvm::LLVMContext &ctx) {
+    auto newModule = std::make_unique<::llvm::Module>("id", ctx);
+    ::llvm::IRBuilder<> builder(ctx);
+    generateLLLVMIrBindings(ctx, *newModule, builder);
+    newModule->print(::llvm::dbgs(), nullptr);
+
 }
 }  // namespace athena::backend
 

--- a/src/backend/llvm/tablegen.py
+++ b/src/backend/llvm/tablegen.py
@@ -159,7 +159,7 @@ def main():
             o.write("#include \"llvm/IR/Constants.h\"\n")
             o.write("#include \"llvm/IR/IRBuilder.h\"\n")
             o.write("void athena::backend::llvm::RuntimeDriver"
-                    "::generateLLLVMIrBindings(::llvm::LLVMContext &ctx, ::llvm::Module &module, "
+                    "::generateLLVMIrBindings(::llvm::LLVMContext &ctx, ::llvm::Module &module, "
                     "::llvm::IRBuilder<> &builder) {\n")
 
         for line in inp:

--- a/src/backend/llvm/tablegen.py
+++ b/src/backend/llvm/tablegen.py
@@ -54,7 +54,7 @@ def generate_llvm(name, signature):
     for template in ["float", "double"]:
         res = ""
         vec_name = get_mangled_name(name, template) + "_args"
-        res += "std::vector<::llvm::Type *> " + vec_name + "(" + str(len(signature)) + ");\n"
+        res += "std::vector<::llvm::Type *> " + vec_name + ";\n"
 
         for arg in signature:
             res += vec_name + ".push_back("
@@ -107,7 +107,14 @@ def main():
     with open(args.outp, "w") as o:
         inp = open(args.inp, "r")
 
-        if args.mode == "driver":
+        if args.mode == "wrapper":
+            o.write("#include <athena/backend/llvm/device/Device.h>\n")
+            o.write("#include <athena/backend/llvm/runtime/builtin.h>\n")
+            o.write("#include <athena/core/inner/Tensor.h>\n")
+            o.write("using namespace athena::backend::llvm;\n")
+            o.write("using namespace athena::core::inner;\n\n")
+            o.write("extern \"C\" {\n")
+        elif args.mode == "driver":
             o.write("#include <athena/backend/llvm/runtime-driver/runtime-driver.h>\n")
             o.write("#include \"llvm/IR/Constants.h\"\n")
             o.write("#include \"llvm/IR/IRBuilder.h\"\n")
@@ -126,6 +133,8 @@ def main():
             elif args.mode == "driver":
                 o.write(generate_llvm(command[0], types))
 
+        if args.mode == "wrapper":
+            o.write("}\n")
         if args.mode == "driver":
             o.write("}\n")
 

--- a/src/backend/llvm/tablegen.py
+++ b/src/backend/llvm/tablegen.py
@@ -1,0 +1,134 @@
+import argparse
+
+plainArgTypes = ["int", "int*", "int *"]
+
+
+def get_mangled_name(name, type):
+    return "athn_" + name + "_" + type[0]
+
+
+def generate_wrapper(name, signature):
+    defs = ""
+    for template in ["float", "double"]:
+        defs += "void "
+        defs += get_mangled_name(name, template)
+        defs += "("
+
+        defs += "void *devicePtr"
+
+        arg_no = 0
+        for arg in signature:
+            defs += ","
+            if arg not in plainArgTypes:
+                defs += " void *arg" + str(arg_no) + "Ptr"
+            else:
+                defs += " " + arg + " arg" + str(arg_no)
+            arg_no += 1
+
+        defs += ") {\n"
+
+        defs += "auto device = reinterpret_cast<Device*>(devicePtr);\n"
+
+        arg_no = 0
+        for arg in signature:
+            if arg not in plainArgTypes:
+                defs += "auto arg" + str(arg_no) + " = reinterpret_cast<" + arg + ">(arg" + str(
+                    arg_no) + "Ptr);\n"
+            arg_no += 1
+        defs += name + "<" + template + ">(device"
+
+        arg_no = 0
+        for arg in signature:
+            defs += ","
+            if arg not in plainArgTypes:
+                defs += " arg" + str(arg_no)
+            else:
+                defs += " " + arg + " arg" + str(arg_no)
+            arg_no += 1
+        defs += ");\n"
+        defs += "}\n"
+    return defs
+
+
+def generate_llvm(name, signature):
+    for template in ["float", "double"]:
+        res = ""
+        vec_name = get_mangled_name(name, template) + "_args"
+        res += "std::vector<::llvm::Type *> " + vec_name + "(" + str(len(signature)) + ");\n"
+
+        for arg in signature:
+            res += vec_name + ".push_back("
+
+            if arg == "int":
+                res += "::llvm::Type::getInt32Ty(ctx)"
+            elif arg == "int *" or arg == "int *":
+                res += "::llvm::Type::getInt32PtrTy(ctx)"
+            else:
+                res += "::llvm::Type::getInt64Ty(ctx)"
+            res += ");\n"
+
+        res += "::llvm::FunctionType *" + get_mangled_name(name, template) + "_FT = "
+        res += "::llvm::FunctionType::get(::llvm::Type::getVoidTy(ctx), " + vec_name + ", false);\n"
+
+        res += "::llvm::Function *" + get_mangled_name(name, template)
+        res += "_F = ::llvm::Function::Create("
+        res += get_mangled_name(name, template) + "_FT, "
+        res += "::llvm::Function::ExternalLinkage, \""
+        res += get_mangled_name(name, template) + "\", &module);\n"
+
+        block_name = get_mangled_name(name, template) + "_block"
+        res += "auto " + block_name + " = ::llvm::BasicBlock::Create(ctx, \"entry\", "
+        res += get_mangled_name(name, template) + "_F);\n"
+
+        res += "builder.SetInsertPoint(" + block_name + ");\n"
+        res += "auto " + get_mangled_name(name, template) + "_ptr = "
+        res += "::llvm::ConstantInt::get(::llvm::Type::getInt64Ty(ctx), " \
+               "reinterpret_cast<uint64_t>(getFunctionPtr(\""
+        res += get_mangled_name(name, template) + "\")));\n"
+
+        res += ""
+
+        res += "builder.CreateCall(" + get_mangled_name(name, template) + "_FT, "
+        res += get_mangled_name(name, template) + "_ptr, "
+        res += "getArgs(" + get_mangled_name(name, template) + "_F));\n"
+
+        return res
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate necessary code for Athena LLVM Runtimes.')
+    parser.add_argument("inp", type=str, help="input file")
+    parser.add_argument("outp", type=str, help="output file")
+    parser.add_argument("mode", type=str, help="mode")
+
+    args = parser.parse_args()
+
+    with open(args.outp, "w") as o:
+        inp = open(args.inp, "r")
+
+        if args.mode == "driver":
+            o.write("#include <athena/backend/llvm/runtime-driver/runtime-driver.h>\n")
+            o.write("#include \"llvm/IR/Constants.h\"\n")
+            o.write("#include \"llvm/IR/IRBuilder.h\"\n")
+            o.write("void athena::backend::llvm::RuntimeDriver"
+                    "::generateLLLVMIrBindings(::llvm::LLVMContext &ctx, ::llvm::Module &module, "
+                    "::llvm::IRBuilder<> &builder) {\n")
+
+        for line in inp:
+            command = line.split(":")
+            types = command[1].split(",")
+            command[0] = command[0].strip()
+            types = list(map(str.strip, types))
+
+            if args.mode == "wrapper":
+                o.write(generate_wrapper(command[0], types))
+            elif args.mode == "driver":
+                o.write(generate_llvm(command[0], types))
+
+        if args.mode == "driver":
+            o.write("}\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/RuntimeDriver/main.cpp
+++ b/tests/integration/RuntimeDriver/main.cpp
@@ -17,45 +17,55 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <string>
+#include <llvm/Support/TargetSelect.h>
+
 
 std::string kPathToRuntimeCPU;
 const std::string kPathToRuntimeCPUName = "PATH_TO_RUNTIME_CPU";
 
-namespace athena::backend {
+namespace athena::backend::llvm {
 
 class RuntimeDriverTest : public ::testing::Test {
     protected:
     void SetUp() override {
+        ::llvm::InitializeNativeTarget();
+        ::llvm::InitializeNativeTargetAsmParser();
+        ::llvm::InitializeNativeTargetAsmPrinter();
         kPathToRuntimeCPU = ::getenv(kPathToRuntimeCPUName.data());
     }
 };
 
-TEST_F(RuntimeDriverTest, TestCreation) {
-    std::string nameLibrary(kPathToRuntimeCPU);
-    kRuntimeDriver.reload(nameLibrary);
-    assert(kRuntimeDriver.isLoaded());
+TEST_F(RuntimeDriverTest, Test1) {
+    static ::llvm::LLVMContext ctx;
+    kRuntimeDriver.prepareModules(ctx);
 }
 
-TEST_F(RuntimeDriverTest, TestLoads) {
-    std::string nameLibrary(kPathToRuntimeCPU);
-    kRuntimeDriver = RuntimeDriver(nameLibrary);
-    assert(kRuntimeDriver.isLoaded());
-    kRuntimeDriver.unload();
-    assert(!kRuntimeDriver.isLoaded());
-    kRuntimeDriver.load(nameLibrary);
-    assert(kRuntimeDriver.isLoaded());
-    kRuntimeDriver.reload(nameLibrary);
-    assert(kRuntimeDriver.isLoaded());
-}
-
-TEST_F(RuntimeDriverTest, TestFunctionCall) {
-    std::string nameLibrary(kPathToRuntimeCPU);
-    constexpr size_t size = 3;
-    float vector_first[] = {1.0, 2.0, 3.0}, vector_second[] = {4.0, 5.0, 6.0},
-          vector_res[size];
-    athena_fadd(vector_first, size, vector_second, size, vector_res);
-    assert(vector_res[0] == 5.0);
-    assert(vector_res[1] == 7.0);
-    assert(vector_res[2] == 9.0);
-}
+//TEST_F(RuntimeDriverTest, TestCreation) {
+//    std::string nameLibrary(kPathToRuntimeCPU);
+//    kRuntimeDriver.reload(nameLibrary);
+//    assert(kRuntimeDriver.isLoaded());
+//}
+//
+//TEST_F(RuntimeDriverTest, TestLoads) {
+//    std::string nameLibrary(kPathToRuntimeCPU);
+//    kRuntimeDriver = RuntimeDriver(nameLibrary);
+//    assert(kRuntimeDriver.isLoaded());
+//    kRuntimeDriver.unload();
+//    assert(!kRuntimeDriver.isLoaded());
+//    kRuntimeDriver.load(nameLibrary);
+//    assert(kRuntimeDriver.isLoaded());
+//    kRuntimeDriver.reload(nameLibrary);
+//    assert(kRuntimeDriver.isLoaded());
+//}
+//
+//TEST_F(RuntimeDriverTest, TestFunctionCall) {
+//    std::string nameLibrary(kPathToRuntimeCPU);
+//    constexpr size_t size = 3;
+//    float vector_first[] = {1.0, 2.0, 3.0}, vector_second[] = {4.0, 5.0, 6.0},
+//          vector_res[size];
+//    athena_fadd(vector_first, size, vector_second, size, vector_res);
+//    assert(vector_res[0] == 5.0);
+//    assert(vector_res[1] == 7.0);
+//    assert(vector_res[2] == 9.0);
+//}
 }  // namespace athena::backend

--- a/tests/integration/RuntimeDriver/main.cpp
+++ b/tests/integration/RuntimeDriver/main.cpp
@@ -11,61 +11,44 @@
  * the License.
  */
 
-#include "athena/backend/llvm/runtime-driver/runtime-driver.h"
+#include <athena/backend/llvm/runtime-driver/runtime-driver.h>
 
-#include <cassert>
 #include <gtest/gtest.h>
-#include <iostream>
-#include <string>
 #include <llvm/Support/TargetSelect.h>
+#include <string>
 
-
-std::string kPathToRuntimeCPU;
-const std::string kPathToRuntimeCPUName = "PATH_TO_RUNTIME_CPU";
+static const std::string kPathToRuntimeCPUName = "PATH_TO_RUNTIME_CPU";
 
 namespace athena::backend::llvm {
 
 class RuntimeDriverTest : public ::testing::Test {
     protected:
+    std::string mPathToRuntimeCPU;
+    std::unique_ptr<::llvm::LLVMContext> mContext =
+        std::make_unique<::llvm::LLVMContext>();
+    RuntimeDriver mDriver;
+
     void SetUp() override {
         ::llvm::InitializeNativeTarget();
         ::llvm::InitializeNativeTargetAsmParser();
         ::llvm::InitializeNativeTargetAsmPrinter();
-        kPathToRuntimeCPU = ::getenv(kPathToRuntimeCPUName.data());
+        mPathToRuntimeCPU = ::getenv(kPathToRuntimeCPUName.data());
     }
+
+    public:
+    RuntimeDriverTest() : mDriver(*mContext) {}
 };
 
-TEST_F(RuntimeDriverTest, Test1) {
-    static ::llvm::LLVMContext ctx;
-    kRuntimeDriver.prepareModules(ctx);
+TEST_F(RuntimeDriverTest, TestCreation) {
+    mDriver.reload(mPathToRuntimeCPU);
+    ASSERT_TRUE(mDriver.isLoaded());
 }
 
-//TEST_F(RuntimeDriverTest, TestCreation) {
-//    std::string nameLibrary(kPathToRuntimeCPU);
-//    kRuntimeDriver.reload(nameLibrary);
-//    assert(kRuntimeDriver.isLoaded());
-//}
-//
-//TEST_F(RuntimeDriverTest, TestLoads) {
-//    std::string nameLibrary(kPathToRuntimeCPU);
-//    kRuntimeDriver = RuntimeDriver(nameLibrary);
-//    assert(kRuntimeDriver.isLoaded());
-//    kRuntimeDriver.unload();
-//    assert(!kRuntimeDriver.isLoaded());
-//    kRuntimeDriver.load(nameLibrary);
-//    assert(kRuntimeDriver.isLoaded());
-//    kRuntimeDriver.reload(nameLibrary);
-//    assert(kRuntimeDriver.isLoaded());
-//}
-//
-//TEST_F(RuntimeDriverTest, TestFunctionCall) {
-//    std::string nameLibrary(kPathToRuntimeCPU);
-//    constexpr size_t size = 3;
-//    float vector_first[] = {1.0, 2.0, 3.0}, vector_second[] = {4.0, 5.0, 6.0},
-//          vector_res[size];
-//    athena_fadd(vector_first, size, vector_second, size, vector_res);
-//    assert(vector_res[0] == 5.0);
-//    assert(vector_res[1] == 7.0);
-//    assert(vector_res[2] == 9.0);
-//}
-}  // namespace athena::backend
+TEST_F(RuntimeDriverTest, TestFunctionLoad) {
+    mDriver.load(mPathToRuntimeCPU);
+    auto &modules = mDriver.getModules();
+    ASSERT_GT(modules.size(), 0);
+
+    ASSERT_NE(modules[0]->getFunction("athn_add_f"), nullptr);
+}
+}  // namespace athena::backend::llvm

--- a/tests/unit/backend/llvm/AthenaJIT.cpp
+++ b/tests/unit/backend/llvm/AthenaJIT.cpp
@@ -45,11 +45,7 @@ class LLVMJITTestType : public ::testing::Test {
         ::llvm::InitializeNativeTarget();
         LLVMInitializeNativeAsmPrinter();
         LLVMInitializeNativeAsmParser();
-        auto jitCompilerWrapper = AthenaJIT::create();
-        if (!jitCompilerWrapper) {
-            llvm::consumeError(jitCompilerWrapper.takeError());
-        }
-        jitCompiler = std::move(jitCompilerWrapper.get());
+        jitCompiler = AthenaJIT::create();
     }
 };
 


### PR DESCRIPTION
Generate LLVM IR modules with proper proxy functions to actual runtime builtins. This makes possible
- call stack optimisations (proxy functions can be inlined)
- LLVM bitcode runtime modules