### PR TITLE
feat: Graph model serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ endif (POLICY CMP0042)
 
 include(AthenaDocs)
 enable_docs()
+set(CMAKE_CXX_STANDARD 17)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
+# todo remove hacks http://lists.llvm.org/pipermail/llvm-dev/2016-May/099874.html
+if (UNIX AND NOT APPLE)
+set(CMAKE_CXX_FLAGS  "-Wl,--export-dynamic")
+endif()
 
 if (NOT ATHENA_DOCS_ONLY)
 

--- a/CMakeModules/AthenaCompileProtobuf.cmake
+++ b/CMakeModules/AthenaCompileProtobuf.cmake
@@ -1,0 +1,18 @@
+function(athena_add_protobuf_module)
+    cmake_parse_arguments(PARSED "" "LIB_NAME;PROTO_DIR" "" ${ARGN})
+
+    find_package(Protobuf REQUIRED)
+
+    file(GLOB SRC ${PARSED_PROTO_DIR}/*.proto)
+
+    PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${SRC})
+
+    add_athena_library(${PARSED_LIB_NAME} OBJECT ${PROTO_SRCS})
+    target_compile_definitions(${PARSED_LIB_NAME} PUBLIC GOOGLE_PROTOBUF_NO_RTTI)
+    target_link_libraries(${PARSED_LIB_NAME} PRIVATE ${PROTOBUF_LIBRARIES})
+    target_include_directories(${PARSED_LIB_NAME}
+            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+            ${PROTOBUF_INCLUDE_DIR})
+
+    export(TARGETS ${PARSED_LIB_NAME} FILE AthenaTarget.cmake)
+endfunction(athena_add_protobuf_module)

--- a/include/athena/core/AbstractLoader.h
+++ b/include/athena/core/AbstractLoader.h
@@ -29,7 +29,7 @@ class AbstractLoader {
     /**
      * Do actual data load
      */
-    virtual void load(Allocator *, inner::Tensor *) = 0;
+    virtual void load(Allocator*, inner::Tensor*) = 0;
     /**
      * Get C-style function name that does actual load
      * For backend usage only
@@ -42,6 +42,19 @@ class AbstractLoader {
      * @return C-style function name string
      */
     virtual std::string getCreateCName() const = 0;
+
+    template <typename T>
+    static std::string getLoaderName() {
+        new FatalError(-1, "Not implemented");
+    };
+
+    virtual std::string getName() const = 0;
+
+    virtual std::string serialize() const = 0;
+
+    static AbstractLoader* deserialize(const std::string& data) {
+        new FatalError(-1, "Not implemented");
+    }
 };
 
 /**
@@ -49,7 +62,7 @@ class AbstractLoader {
  */
 class DummyLoader : public AbstractLoader {
     public:
-    void load(Allocator *, inner::Tensor *tensor) override {}
+    void load(Allocator*, inner::Tensor* tensor) override {}
     std::string getLoadCName() const override {
         static const std::string loadName = "DummyLoad";
         return loadName;
@@ -57,6 +70,18 @@ class DummyLoader : public AbstractLoader {
     virtual std::string getCreateCName() const override {
         static const std::string createName = "DummyCreate";
         return createName;
+    }
+
+    virtual std::string serialize() const override {
+        return "";
+    }
+
+    virtual std::string getName() const override {
+        return "dummy";
+    }
+
+    static AbstractLoader* deserialize(const std::string& data) {
+        return new DummyLoader();
     }
 };
 }  // namespace athena::core

--- a/include/athena/core/Graph.h
+++ b/include/athena/core/Graph.h
@@ -19,6 +19,7 @@
 #include <athena/core/inner/Settings.h>
 #include <athena/core/inner/Table.h>
 
+#include <ostream>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>

--- a/include/athena/core/Operation.h
+++ b/include/athena/core/Operation.h
@@ -32,15 +32,15 @@ class Operation {
     std::string mName;
 
     public:
-    explicit Operation(std::string name)
-        :
-          mName(std::move(name)){};
+    explicit Operation(std::string name) : mName(std::move(name)){};
     virtual inner::Tensor* getResultTensor(
         core::Context& context, std::vector<inner::Tensor*> args) const = 0;
-    virtual inner::Tensor* getErrorTensor(core::Context& context, std::vector<inner::Tensor*> args,
+    virtual inner::Tensor* getErrorTensor(core::Context& context,
+                                          std::vector<inner::Tensor*> args,
                                           int derivativeOrder) const = 0;
     virtual inner::Tensor* getDerivativeTensor(core::Context& context,
-        std::vector<inner::Tensor*> args, int argNo) const = 0;
+                                               std::vector<inner::Tensor*> args,
+                                               int argNo) const = 0;
 
     /**
      * Generate code for Operation
@@ -73,6 +73,12 @@ class Operation {
     std::string getName() const;
 
     virtual size_t getOperandsCount() const = 0;
+
+    virtual std::string serialize() const = 0;
+
+    static Operation* deserialize(const std::string& data) {
+        return nullptr;
+    };
 };
 
 class OperationDummy : public Operation {
@@ -80,16 +86,19 @@ class OperationDummy : public Operation {
     explicit OperationDummy(std::string name) : Operation(std::move(name)){};
 
     inner::Tensor* getResultTensor(
-        core::Context& context, std::vector<inner::Tensor*> args) const override {
+        core::Context& context,
+        std::vector<inner::Tensor*> args) const override {
         return inner::getNullTensor(context);
     }
 
-    inner::Tensor* getErrorTensor(core::Context& context, std::vector<inner::Tensor*>,
+    inner::Tensor* getErrorTensor(core::Context& context,
+                                  std::vector<inner::Tensor*>,
                                   int) const override {
         return inner::getNullTensor(context);
     }
 
-    inner::Tensor* getDerivativeTensor(core::Context& context, std::vector<inner::Tensor*> args,
+    inner::Tensor* getDerivativeTensor(core::Context& context,
+                                       std::vector<inner::Tensor*> args,
                                        int argNo) const override {
         return inner::getNullTensor(context);
     }
@@ -112,6 +121,14 @@ class OperationDummy : public Operation {
     size_t getOperandsCount() const override {
         return 0;
     }
+
+    std::string serialize() const override {
+        return "";
+    }
+
+    static Operation* deserialize(const std::string&) {
+        return new OperationDummy("dummy");
+    };
 };
 }  // namespace athena::core
 

--- a/include/athena/core/inner/LoaderFactory.h
+++ b/include/athena/core/inner/LoaderFactory.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef ATHENA_LOADERFACTORY_H
+#define ATHENA_LOADERFACTORY_H
+
+#include <athena/core/AbstractLoader.h>
+#include <athena/loaders/MemoryLoader/MemoryLoader.h>
+
+#include <unordered_map>
+
+namespace athena::core::inner {
+
+class LoaderFactory {
+    private:
+    std::unordered_map<std::string, AbstractLoader *(*)(const std::string &)>
+        loadersMap;
+
+    LoaderFactory() {
+        registerLoader<loaders::MemoryLoader>();
+        registerLoader<DummyLoader>();
+    }
+
+    public:
+    static LoaderFactory &getInstance() {
+        static LoaderFactory loaderFactory;
+        return loaderFactory;
+    }
+
+    static AbstractLoader *createLoader(const std::string &name,
+                                        const std::string &data) {
+        return getInstance().loadersMap[name](data);
+    }
+    template <typename T>
+    void registerLoader() {
+        loadersMap[T::template getLoaderName<T>()] = &T::deserialize;
+    }
+};
+}  // namespace athena::core::inner
+
+#endif  // ATHENA_LOADERFACTORY_H

--- a/include/athena/core/inner/OperationFactory.h
+++ b/include/athena/core/inner/OperationFactory.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef ATHENA_OPERATIONFACTORY_H
+#define ATHENA_OPERATIONFACTORY_H
+
+#include <athena/core/Operation.h>
+#include <athena/ops/AddOperation.h>
+#include <athena/ops/GEMMOperation.h>
+#include <athena/ops/MSELossFunction.h>
+
+#include <unordered_map>
+
+namespace athena::core::inner {
+
+class OperationFactory {
+    private:
+    std::unordered_map<std::string, Operation *(*)(const std::string &)> opsMap;
+
+    OperationFactory() {
+        registerOperation<OperationDummy>("dummy");
+        registerOperation<ops::AddOperation>("add");
+        registerOperation<ops::MSELossFunction>("mse");
+        registerOperation<ops::GEMMOperation>("gemm");
+    }
+
+    public:
+    static OperationFactory &getInstance() {
+        static OperationFactory operationFactory;
+        return operationFactory;
+    }
+
+    static Operation *createOperation(const std::string &name,
+                                      const std::string &data) {
+        return getInstance().opsMap[name](data);
+    }
+
+    template <typename T>
+    void registerOperation(const std::string &name) {
+        opsMap[name] = &T::deserialize;
+    }
+};
+}  // namespace athena::core::inner
+
+#endif  // ATHENA_OPERATIONFACTORY_H

--- a/include/athena/loaders/MemoryLoader/MemoryLoader.h
+++ b/include/athena/loaders/MemoryLoader/MemoryLoader.h
@@ -43,6 +43,16 @@ class MemoryLoader : public core::AbstractLoader {
         static const std::string createName = "CreateMemoryLoader";
         return createName;
     };
+
+    virtual std::string getName() const override {
+        return "MemoryLoader";
+    }
+
+    std::string serialize() const override;
+
+    static AbstractLoader *deserialize(const std::string &data) {
+        new core::FatalError(-1, "MemoryLoader is not serializable");
+    }
 };
 }  // namespace athena::loaders
 

--- a/include/athena/model/NativeModel.h
+++ b/include/athena/model/NativeModel.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef ATHENA_NATIVEMODEL_H
+#define ATHENA_NATIVEMODEL_H
+
+#include <athena/core/Graph.h>
+
+#include <istream>
+#include <ostream>
+
+namespace athena::model {
+class NativeModel {
+    public:
+    static void serializeGraph(core::Graph &graph, std::ostream &stream);
+    static void deserializeGraph(core::Graph &graph, std::istream &stream);
+    static void saveGraphToFile(core::Graph &graph,
+                                const std::string &filename);
+    static void readGraphFromFile(core::Graph &graph, const std::string &name);
+};
+}  // namespace athena::model
+
+#endif  // ATHENA_NATIVEMODEL_H

--- a/include/athena/ops/AddOperation.h
+++ b/include/athena/ops/AddOperation.h
@@ -45,6 +45,14 @@ class AddOperation : public core::Operation {
     size_t getOperandsCount() const override {
         return 2;
     }
+
+    std::string serialize() const override {
+        return "";
+    }
+
+    static Operation *deserialize(const std::string &) {
+        return new AddOperation();
+    };
 };
 }  // namespace athena::ops
 #endif  // ATHENA_ADDOPERATION_H

--- a/include/athena/ops/GEMMOperation.h
+++ b/include/athena/ops/GEMMOperation.h
@@ -44,6 +44,15 @@ class GEMMOperation : public core::Operation {
     size_t getOperandsCount() const override {
         return 2;
     }
+    std::string serialize() const override;
+
+    static Operation *deserialize(const std::string &data) {
+        std::stringstream stream(data);
+        bool transpA, transpB;
+        stream >> transpA;
+        stream >> transpB;
+        return new GEMMOperation(transpA, transpB);
+    };
 };
 }  // namespace athena::ops
 

--- a/include/athena/ops/MSELossFunction.h
+++ b/include/athena/ops/MSELossFunction.h
@@ -42,6 +42,11 @@ class MSELossFunction : public core::Operation {
     size_t getOperandsCount() const override {
         return 2;
     }
+    std::string serialize() const override;
+
+    static Operation *deserialize(const std::string &) {
+        return new MSELossFunction();
+    };
 };
 }  // namespace athena::ops
 #endif  // ATHENA_MSELOSSFUNCTION_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(backend)
 add_subdirectory(core)
 add_subdirectory(ops)
 add_subdirectory(loaders)
+add_subdirectory(model)
 
 # Define headers for this library. PUBLIC headers are used for
 # compiling the library, and will be added to consumers' build
@@ -38,6 +39,7 @@ target_link_libraries(athena
         backend-llvm
         athena-core
         athena-ops
+        athena-model
         ${NOWHOLE_ARCHIVE})
 
 target_compile_features(athena

--- a/src/core/AbstractLoader.cpp
+++ b/src/core/AbstractLoader.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <athena/core/AbstractLoader.h>
+
+namespace athena::core {
+template <>
+std::string AbstractLoader::getLoaderName<DummyLoader>() {
+    return "dummy";
+}
+}

--- a/src/loaders/MemoryLoader/CMakeLists.txt
+++ b/src/loaders/MemoryLoader/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_athena_library(MemoryLoader STATIC MemoryLoader.cpp)
+add_athena_library(MemoryLoader OBJECT MemoryLoader.cpp)
 target_link_libraries(MemoryLoader PRIVATE athena-core)

--- a/src/loaders/MemoryLoader/MemoryLoader.cpp
+++ b/src/loaders/MemoryLoader/MemoryLoader.cpp
@@ -49,8 +49,19 @@ void MemoryLoader::load(core::Allocator *allocator,
 #endif
     std::memmove(pointer, mData, mSize);
 }
+std::string MemoryLoader::serialize() const {
+    new core::FatalError(-1, "Not serializable");
+}
 
 }  // namespace athena::loaders
+
+namespace athena::core {
+template <>
+std::string
+core::AbstractLoader::getLoaderName<athena::loaders::MemoryLoader>() {
+    return "MemoryLoader";
+}
+}  // namespace athena::core
 
 extern "C" {
 void MemoryLoaderLoad(void *loader, void *allocator, void *tensor) {

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_athena_library(athena-model STATIC NativeModel.cpp)
+
+include(AthenaCompileProtobuf)
+
+athena_add_protobuf_module(LIB_NAME athena-graph-proto
+        PROTO_DIR ${PROJECT_SOURCE_DIR}/utils/graph_proto)
+target_link_libraries(athena-model PUBLIC athena-graph-proto)

--- a/src/model/NativeModel.cpp
+++ b/src/model/NativeModel.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2019 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <athena/core/DataType.h>
+#include <athena/core/Graph.h>
+#include <athena/core/InputNode.h>
+#include <athena/core/LossNode.h>
+#include <athena/core/Node.h>
+#include <athena/core/OutputNode.h>
+#include <athena/core/inner/LoaderFactory.h>
+#include <athena/core/inner/OperationFactory.h>
+#include <athena/model/NativeModel.h>
+
+#include <Graph.pb.h>
+#include <fstream>
+
+using namespace athena::core;
+
+namespace athena::model {
+static proto_graph::Tensor_DataType nativeToProtoDataType(DataType type) {
+    using Type = proto_graph::Tensor_DataType;
+    switch (type) {
+        case DataType::FLOAT:
+            return Type::Tensor_DataType_FLOAT;
+        case DataType::DOUBLE:
+            return Type::Tensor_DataType_DOUBLE;
+        case DataType::HALF:
+            return Type::Tensor_DataType_HALF;
+        default:
+            return Type::Tensor_DataType_UNDEFINED;
+    }
+}
+static proto_graph::Tensor serializeTensor(const inner::Tensor& tensor) {
+    proto_graph::Tensor t;
+    for (size_t i = 0; i < tensor.getShape().dimensions(); i++) {
+        t.add_dimensions(tensor.getShape().dim(i));
+    }
+    t.set_data_type(nativeToProtoDataType(tensor.getDataType()));
+    return t;
+}
+static proto_graph::Loader serializeLoader(const AbstractLoader& loader) {
+    proto_graph::Loader l;
+    l.set_name(loader.getName());
+    l.set_data(loader.serialize());
+    return l;
+}
+static proto_graph::Operation serializeOperation(const Operation& operation) {
+    proto_graph::Operation op;
+    op.set_name(operation.getName());
+    op.set_data(operation.serialize());
+    return op;
+}
+static void serializeNode(proto_graph::Node* actionNode, Node& node) {
+    actionNode->set_index(node.getNodeIndex());
+    actionNode->set_name(node.getName().data());
+    auto* tensor = new proto_graph::Tensor(
+        serializeTensor(inner::getTensorFromNode(node)));
+    actionNode->set_allocated_tensor(tensor);
+    auto* operation =
+        new proto_graph::Operation(serializeOperation(node.getOperation()));
+    actionNode->set_allocated_operation(operation);
+    actionNode->set_inputs_count(node.getInputsCount());
+}
+static void serializeInputNode(proto_graph::InputNode* inputNode,
+                               InputNode& node) {
+    inputNode->set_index(node.getNodeIndex());
+    inputNode->set_name(node.getName().data());
+    auto* tensor = new proto_graph::Tensor(
+        serializeTensor(inner::getTensorFromNode(node)));
+    inputNode->set_allocated_tensor(tensor);
+    auto* loader = new proto_graph::Loader(serializeLoader(node.getLoader()));
+    inputNode->set_allocated_loader(loader);
+    inputNode->set_is_frozen(node.isFrozen());
+}
+static void serializeLossNode(proto_graph::LossNode* lossNode, LossNode& node) {
+    lossNode->set_index(node.getNodeIndex());
+    lossNode->set_name(node.getName().data());
+    auto* tensor = new proto_graph::Tensor(
+        serializeTensor(inner::getTensorFromNode(node)));
+    lossNode->set_allocated_tensor(tensor);
+    auto* operation =
+        new proto_graph::Operation(serializeOperation(node.getOperation()));
+    lossNode->set_allocated_operation(operation);
+    lossNode->set_criterion(static_cast<size_t>(node.getCriterion()));
+    lossNode->set_inputs_count(node.getInputsCount());
+}
+static void serializeOutputNode(proto_graph::OutputNode* outputNode,
+                                OutputNode& node) {
+    outputNode->set_index(node.getNodeIndex());
+    outputNode->set_name(node.getName().data());
+    outputNode->set_inputs_count(node.getInputsCount());
+}
+
+void NativeModel::serializeGraph(core::Graph& graph, std::ostream& stream) {
+    proto_graph::Graph savedGraph;
+
+    auto topology = graph.getTopology();
+    auto owningStorage = graph.getOwningStorage();
+    auto syncStorage = graph.getSyncStorage();
+
+    for (auto& edge : topology) {
+        auto* e = savedGraph.add_edges();
+        e->set_mark(edge.mark);
+        e->set_end(edge.endNodeIndex);
+        e->set_start(edge.startNodeIndex);
+    }
+
+    auto& inputNodes = std::get<std::vector<InputNode>>(owningStorage);
+    for (auto& node : inputNodes) {
+        serializeInputNode(savedGraph.add_input_nodes(), node);
+    }
+    auto& actionNodes = std::get<std::vector<Node>>(owningStorage);
+    for (auto& node : actionNodes) {
+        serializeNode(savedGraph.add_nodes(), node);
+    }
+    auto& lossNodes = std::get<std::vector<LossNode>>(owningStorage);
+    for (auto& node : lossNodes) {
+        serializeLossNode(savedGraph.add_loss_nodes(), node);
+    }
+    auto& outputNodes = std::get<std::vector<OutputNode>>(owningStorage);
+    for (auto& node : outputNodes) {
+        serializeOutputNode(savedGraph.add_output_nodes(), node);
+    }
+
+    auto& ctx = inner::getContext(graph);
+
+    for (size_t idx : syncStorage) {
+        auto* syncNode = inner::getNodeTable(ctx)[idx];
+#ifdef DEBUG
+        assert(syncNode);
+#endif
+        if (syncNode->getType() == NodeType::DEFAULT) {
+            serializeNode(savedGraph.add_nodes(),
+                          *node_dyncast<Node*>(syncNode));
+        } else if (syncNode->getType() == NodeType::INPUT) {
+            serializeInputNode(savedGraph.add_input_nodes(),
+                               *node_dyncast<InputNode*>(syncNode));
+        } else if (syncNode->getType() == NodeType::LOSS) {
+            serializeLossNode(savedGraph.add_loss_nodes(),
+                              *node_dyncast<LossNode*>(syncNode));
+        } else if (syncNode->getType() == NodeType::OUTPUT) {
+            serializeOutputNode(savedGraph.add_output_nodes(),
+                                *node_dyncast<OutputNode*>(syncNode));
+        } else {
+            new FatalError(1, "Attempt to serialize unsupported node type: ",
+                           syncNode->getName());
+        }
+    }
+
+    savedGraph.SerializePartialToOstream(&stream);
+}
+void NativeModel::saveGraphToFile(core::Graph& graph,
+                                  const std::string& filename) {
+    std::ofstream out(filename);
+    NativeModel::serializeGraph(graph, out);
+    out.close();
+}
+
+static TensorShape getShape(const proto_graph::Tensor& t) {
+    std::vector<size_t> dims(t.dimensions().begin(), t.dimensions().end());
+    TensorShape shape(dims);
+    return std::move(shape);
+}
+static DataType protoToNativeDataType(const proto_graph::Tensor& t) {
+    using Type = proto_graph::Tensor_DataType;
+    switch (t.data_type()) {
+        case Type::Tensor_DataType_FLOAT:
+            return DataType::FLOAT;
+        case Type::Tensor_DataType_DOUBLE:
+            return DataType::DOUBLE;
+        case Type::Tensor_DataType_HALF:
+            return DataType::HALF;
+        default:
+            return DataType::UNDEFINED;
+    }
+}
+AbstractLoader* deserializeLoader(const proto_graph::Loader& loader) {
+    // this looks like cause for memory leak, needs investigation
+    return inner::LoaderFactory::createLoader(loader.name(), loader.data());
+}
+
+Operation* deserializeOperation(const proto_graph::Operation& operation) {
+    // this looks like cause for memory leak, needs investigation
+    return inner::OperationFactory::createOperation(operation.name(),
+                                                    operation.data());
+}
+
+void NativeModel::deserializeGraph(core::Graph& graph, std::istream& stream) {
+    proto_graph::Graph protograph;
+    protograph.ParseFromIstream(&stream);
+
+    std::unordered_map<size_t, size_t> nodesRemap;
+
+    auto& ctx = inner::getContext(graph);
+
+    for (auto& node : protograph.input_nodes()) {
+        InputNode n(
+            getShape(node.tensor()), protoToNativeDataType(node.tensor()),
+                    *deserializeLoader(node.loader()), ctx, node.is_frozen(),
+                    node.name());
+        graph.addNode(n);
+        nodesRemap[node.index()] = n.getNodeIndex();
+    }
+
+    for (auto& node : protograph.nodes()) {
+        Node n(*deserializeOperation(node.operation()), ctx, node.name());
+        graph.addNode(n);
+        nodesRemap[node.index()] = n.getNodeIndex();
+    }
+
+    for (auto& node : protograph.loss_nodes()) {
+        LossNode n(*deserializeOperation(node.operation()),
+                   static_cast<Criterion>(node.criterion()), ctx, node.name());
+        graph.addNode(n);
+        nodesRemap[node.index()] = n.getNodeIndex();
+    }
+
+    for (auto& node : protograph.output_nodes()) {
+        // OutputNode creates 0-dimension tensor, so UNDEFINED is ok here
+        OutputNode n(DataType::UNDEFINED, ctx, node.name());
+        graph.addNode(n);
+        nodesRemap[node.index()] = n.getNodeIndex();
+    }
+
+    for (auto& edge : protograph.edges()) {
+        auto* startNode = inner::getNodeTable(ctx)[nodesRemap[edge.start()]];
+        auto* endNode = inner::getNodeTable(ctx)[nodesRemap[edge.end()]];
+        endNode->after(*startNode, edge.mark());
+    }
+}
+void NativeModel::readGraphFromFile(core::Graph& graph,
+                                    const std::string& name) {
+    std::ifstream stream(name);
+    NativeModel::deserializeGraph(graph, stream);
+    stream.close();
+}
+}

--- a/src/ops/CMakeLists.txt
+++ b/src/ops/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_athena_library(athena-ops STATIC AddOperation.cpp MSELossFunction.cpp GEMMOperation.cpp)
+add_athena_library(athena-ops OBJECT AddOperation.cpp MSELossFunction.cpp GEMMOperation.cpp)

--- a/src/ops/GEMMOperation.cpp
+++ b/src/ops/GEMMOperation.cpp
@@ -89,4 +89,9 @@ core::inner::Tensor *GEMMOperation::getErrorTensor(core::Context& context,
     // todo higher orders not supported
     return getResultTensor(context, args);
 }
+std::string GEMMOperation::serialize() const {
+    std::stringstream stringstream;
+    stringstream << mTransposeA << std::endl << mTransposeB << std::endl;
+    return stringstream.str();
+}
 }

--- a/src/ops/MSELossFunction.cpp
+++ b/src/ops/MSELossFunction.cpp
@@ -77,4 +77,7 @@ core::inner::Tensor *MSELossFunction::getErrorTensor(core::Context& context,
     // todo refactor me
     return nullptr;
 }
+std::string MSELossFunction::serialize() const {
+    return "";
+}
 }  // namespace athena::ops

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(core)
 add_subdirectory(loaders)
 add_subdirectory(backend)
+add_subdirectory(model)

--- a/tests/unit/model/CMakeLists.txt
+++ b/tests/unit/model/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_athena_executable(TestUnitModelRunnable NativeModel.cpp)
+target_link_libraries(TestUnitModelRunnable PRIVATE
+        athena
+        Threads::Threads
+        AthenaDep::googletest)
+
+add_test(NAME ModelUnitTest COMMAND TestUnitModelRunnable)

--- a/tests/unit/model/NativeModel.cpp
+++ b/tests/unit/model/NativeModel.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <athena/core/Context.h>
+#include <athena/core/Criterion.h>
+#include <athena/core/Graph.h>
+#include <athena/core/LossNode.h>
+#include <athena/model/NativeModel.h>
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace athena::core;
+using namespace athena::model;
+
+static bool findNodeByNameInGraph(Graph& graph, const std::string& name) {
+    auto& owningStorage = graph.getOwningStorage();
+    auto& inputNodes = std::get<std::vector<InputNode>>(owningStorage);
+    for (auto& node : inputNodes) {
+        if (node.getName() == name) {
+            return true;
+        }
+    }
+    auto& actionNodes = std::get<std::vector<Node>>(owningStorage);
+    for (auto& node : actionNodes) {
+        if (node.getName() == name) {
+            return true;
+        }
+    }
+    auto& lossNodes = std::get<std::vector<LossNode>>(owningStorage);
+    for (auto& node : lossNodes) {
+        if (node.getName() == name) {
+            return true;
+        }
+    }
+    auto& outputNodes = std::get<std::vector<OutputNode>>(owningStorage);
+    for (auto& node : outputNodes) {
+        if (node.getName() == name) {
+            return true;
+        }
+    }
+    return false;
+}
+
+TEST(ModelTest, NativeModelSmokeTest) {
+    // Arrange
+    Context ctx;
+    Graph graph(ctx);
+
+    DummyLoader dummyLoader;
+    InputNode input({0}, DataType::UNDEFINED, dummyLoader, ctx, true, "input");
+    graph.addNode(input);
+
+    OperationDummy dummyOp("dummy");
+    Node node(dummyOp, ctx, "node");
+    graph.addNode(node);
+    node.after(input, 1);
+
+    LossNode loss(dummyOp, Criterion::UNDEFINED, ctx, "loss");
+    graph.addNode(loss);
+    loss.after(node, 1);
+
+    OutputNode output(DataType::UNDEFINED, ctx, "output");
+    graph.addNode(output);
+    output.after(loss, 1);
+
+    // Act
+    NativeModel::saveGraphToFile(graph, "file.model");
+    Graph newGraph(ctx);
+    NativeModel::readGraphFromFile(newGraph, "file.model");
+
+    // Assert
+    EXPECT_TRUE(findNodeByNameInGraph(newGraph, "input"));
+    EXPECT_TRUE(findNodeByNameInGraph(newGraph, "node"));
+    EXPECT_TRUE(findNodeByNameInGraph(newGraph, "loss"));
+    EXPECT_TRUE(findNodeByNameInGraph(newGraph, "output"));
+}

--- a/utils/graph_proto/Edge.proto
+++ b/utils/graph_proto/Edge.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package proto_graph;
+
+message Edge {
+    uint64 start = 1;
+    uint64 end = 2;
+    uint64 mark = 3;
+}

--- a/utils/graph_proto/Graph.proto
+++ b/utils/graph_proto/Graph.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+import "Node.proto";
+import "InputNode.proto";
+import "OutputNode.proto";
+import "LossNode.proto";
+import "Edge.proto";
+
+package proto_graph;
+
+message Graph {
+    repeated Node nodes = 1;
+    repeated InputNode input_nodes = 2;
+    repeated OutputNode output_nodes = 3;
+    repeated LossNode loss_nodes = 4;
+    repeated Edge edges = 5;
+}

--- a/utils/graph_proto/InputNode.proto
+++ b/utils/graph_proto/InputNode.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package proto_graph;
+
+import "Tensor.proto";
+import "Loader.proto";
+
+message InputNode {
+    uint64 index = 1;
+    string name = 2;
+    Tensor tensor = 3;
+    Loader loader = 4;
+    bool is_frozen = 5;
+}

--- a/utils/graph_proto/Loader.proto
+++ b/utils/graph_proto/Loader.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package proto_graph;
+
+message Loader {
+    string name = 1;
+    string data = 2;
+}

--- a/utils/graph_proto/LossNode.proto
+++ b/utils/graph_proto/LossNode.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package proto_graph;
+
+import "Tensor.proto";
+import "Operation.proto";
+
+message LossNode {
+    uint64 index = 1;
+    string name = 2;
+    Tensor tensor = 3;
+    uint64 inputs_count = 4;
+    Operation operation = 5;
+    uint64 criterion = 6;
+}

--- a/utils/graph_proto/Node.proto
+++ b/utils/graph_proto/Node.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package proto_graph;
+
+import "Tensor.proto";
+import "Operation.proto";
+
+message Node {
+    uint64 index = 1;
+    string name = 2;
+    Tensor tensor = 3;
+    uint64 inputs_count = 4;
+    Operation operation = 5;
+}

--- a/utils/graph_proto/Operation.proto
+++ b/utils/graph_proto/Operation.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package proto_graph;
+
+message Operation {
+    string name = 1;
+    string data = 2;
+}

--- a/utils/graph_proto/OutputNode.proto
+++ b/utils/graph_proto/OutputNode.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package proto_graph;
+
+message OutputNode {
+    uint64 index = 1;
+    string name = 2;
+    uint64 inputs_count = 3;
+}

--- a/utils/graph_proto/Tensor.proto
+++ b/utils/graph_proto/Tensor.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package proto_graph;
+
+message Tensor {
+    repeated uint64 dimensions = 1;
+    enum DataType {
+        UNDEFINED = 0;
+        FLOAT = 1;
+        DOUBLE = 2;
+        HALF = 3;
+    }
+    DataType data_type = 2;
+}


### PR DESCRIPTION
This patch introduces Graph serialization to a native
Google Protobuf-based format. Models can be serialized
either to C++ stream or to a file.

Co-authored-by: Andrey Morkovkin <mork.andrey.s.dev@gmail.com>
Signed-off-by: Alexander Batashev <alexbatashev@outlook.com>