### PR TITLE
[NFC] feat: Introduce new Generator infrastructure

### DIFF
--- a/include/athena/core/Generator.h
+++ b/include/athena/core/Generator.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef ATHENA_GENERATOR_H
+#define ATHENA_GENERATOR_H
+
+#include <athena/core/Context.h>
+#include <athena/core/inner/Tensor.h>
+
+#include <any>
+#include <functional>
+#include <unordered_map>
+#include <utility>
+
+namespace athena::core {
+
+/// A bridge between \c GraphCompiler and a backend.
+class ATH_CORE_EXPORT Generator {
+    public:
+    using FunctorType = std::function<void(Context &,
+                                           std::any &,
+                                           size_t,
+                                           const std::string &,
+                                           size_t,
+                                           const std::vector<inner::Tensor> &,
+                                           const std::any &)>;
+
+    private:
+    std::unordered_map<std::string, FunctorType> mRegisteredFunctors;
+    Context &mContext;
+    std::any mGeneratorState;
+
+    public:
+    /// Constructs a Generator.
+    ///
+    /// \param ctx is an Athena context.
+    /// \param state is used by functors to emit IR/code/etc. Its real type
+    /// is defined by the backend.
+    Generator(Context &ctx, std::any state)
+        : mContext(ctx), mGeneratorState(std::move(state)){};
+
+    /// Registers functor for specific name.
+    ///
+    /// \param name is a name to associate functor to.
+    /// \param functor is a functor type object (lambda, functor type, function
+    /// pointer) that provides routines to generate code for builtin.
+    void registerFunctor(const std::string &name, FunctorType functor);
+
+    /// @return true if a functor with name is registered.
+    [[nodiscard]] bool hasFunctor(const std::string &name) const {
+        return mRegisteredFunctors.count(name);
+    }
+
+    /// Removes any functor associated with the specified name.
+    ///
+    /// \param name is a functor name.
+    void unregisterFunctor(const std::string &name);
+
+    /// Calls functor corresponding to provided builtin name.
+    ///
+    /// \param functorName is a name of builtin to generate code for.
+    /// \param nodeId is an identifier of a node that code is generated for.
+    /// \param nodeName is a name of a node that code is generated for.
+    /// \param clusterId is an identifier of a cluster that contains a node that
+    /// code is generated for.
+    /// \param args is a vector of tensors that contains both arguments and
+    /// resulting tensor.
+    /// \param options is an optional builtin options object.
+    void generate(const std::string &functorName,
+                  size_t nodeId,
+                  const std::string &nodeName,
+                  size_t clusterId,
+                  const std::vector<inner::Tensor> &args,
+                  const std::any &options = nullptr);
+};
+}  // namespace athena::core
+
+#endif  // ATHENA_GENERATOR_H

--- a/src/backend/llvm/mlir/CMakeLists.txt
+++ b/src/backend/llvm/mlir/CMakeLists.txt
@@ -7,6 +7,8 @@ add_athena_library(
         MLIRGenerator.cpp
 )
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tablegen)
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tablegen/GraphDialect.h.inc
         ${CMAKE_CURRENT_BINARY_DIR}/tablegen/GraphDialect.h.fake
         COMMAND ${MLIR_TBLGEN} --gen-op-decls -o=${CMAKE_CURRENT_BINARY_DIR}/tablegen/GraphDialect.h.inc

--- a/src/core/Generator.cpp
+++ b/src/core/Generator.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <athena/core/Generator.h>
+
+namespace athena::core {
+void Generator::registerFunctor(const std::string& name, FunctorType functor) {
+    mRegisteredFunctors[name] = std::move(functor);
+}
+void Generator::unregisterFunctor(const std::string& name) {
+    if (hasFunctor(name)) {
+        mRegisteredFunctors.erase(name);
+    }
+}
+void Generator::generate(const std::string& functorName,
+                         size_t nodeId,
+                         const std::string& nodeName,
+                         size_t clusterId,
+                         const std::vector<inner::Tensor>& args,
+                         const std::any& options) {
+    if (!hasFunctor(functorName))
+        new FatalError(FatalErrorType::ATH_NOT_IMPLEMENTED,
+                       "No functor with name ", functorName);
+
+    mRegisteredFunctors[functorName](mContext, mGeneratorState, nodeId,
+                                     nodeName, clusterId, args, options);
+}
+}  // namespace athena::core

--- a/tests/regression/backend/mlir/CMakeLists.txt
+++ b/tests/regression/backend/mlir/CMakeLists.txt
@@ -7,9 +7,6 @@ find_package(MLIR COMPONENTS IR)
 add_athena_integration_test(
         TARGET_NAME MLIRRegression
         SRCS ${REG_TEST_SRC}
-        LIBS athena AthenaDep::effcee ${MLIR_LIBS} ${ATH_BACKEND_LLVM_MLIR}
-        /opt/llvm10/lib/libMLIRDialect.a
-        /opt/llvm10/lib/libMLIREDSC.a
-        /opt/llvm10/lib/libMLIRSupport.a
-)
+        LIBS athena AthenaDep::effcee ${MLIR_LIBS} ${ATH_BACKEND_LLVM_MLIR})
+
 target_include_directories(TestIntegrationMLIRRegressionRunnable PRIVATE ${MLIR_INCLUDE_DIRS})

--- a/tests/unit/core/Generator.cpp
+++ b/tests/unit/core/Generator.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020 Athena. All rights reserved.
+ * https://getathena.ml
+ *
+ * Licensed under MIT license.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <athena/core/Context.h>
+#include <athena/core/Generator.h>
+#include <athena/core/inner/Tensor.h>
+
+#include <any>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace athena::core;
+
+struct DummyState {
+    bool flag = false;
+};
+
+TEST(GeneratorTest, AddSimpleFunctor) {
+    // Arrange
+    Context ctx;
+    auto state = std::make_shared<DummyState>();
+    Generator generator(ctx, state);
+
+    auto f = [&](Context &ctx, std::any &genImpl, size_t nodeId,
+                 const std::string &nodeName, size_t clusterId,
+                 const std::vector<inner::Tensor> &args,
+                 const std::any &opts) {};
+
+    // Act
+    generator.registerFunctor("test", f);
+
+    // Assert
+    ASSERT_TRUE(generator.hasFunctor("test"));
+}
+
+TEST(GeneratorTest, RemoveFunctor) {
+    // Arrange
+    Context ctx;
+    auto state = std::make_shared<DummyState>();
+    Generator generator(ctx, state);
+
+    auto f = [&](Context &ctx, std::any &genImpl, size_t nodeId,
+                 const std::string &nodeName, size_t clusterId,
+                 const std::vector<inner::Tensor> &args,
+                 const std::any &opts) {};
+
+    // Act
+    generator.registerFunctor("test", f);
+    EXPECT_TRUE(generator.hasFunctor("test"));
+    generator.unregisterFunctor("test");
+
+    // Assert
+    EXPECT_FALSE(generator.hasFunctor("test"));
+}
+
+TEST(GeneratorTest, BehavesCorrectly) {
+    // Arrange
+    Context ctx;
+    auto state = std::make_shared<DummyState>();
+    Generator generator(ctx, state);
+
+    auto f = [&](Context &ctx, std::any &genImpl, size_t nodeId,
+                 const std::string &nodeName, size_t clusterId,
+                 const std::vector<inner::Tensor> &args, const std::any &opts) {
+        auto state = std::any_cast<std::shared_ptr<DummyState>>(genImpl);
+        state->flag = true;
+    };
+    generator.registerFunctor("test", f);
+
+    // Act
+    generator.generate("test", 0, "", 0, {});
+
+    // Assert
+    ASSERT_TRUE(state->flag);
+}


### PR DESCRIPTION
The existing generator interface is very specific to the needs of LLVM backend. It uses such a terms as 'function', 'node', etc. While those make sense for one backends, they may have no meaning for other. As part of effort to bring MLIR into Athena, a new Generator infrastructure is introduced. It aims to be flexible and extensible without respect to underlying backends. LLVM backend can still map data, that is passed to new generator, to functions and whatever other structures it needs.

Transition to the new infrastructure will be done in future patches.

Meta: ATH-13