### PR TITLE
fix: numerous bugs in backend

### DIFF
--- a/include/athena/backend/llvm/BackendAllocator.h
+++ b/include/athena/backend/llvm/BackendAllocator.h
@@ -39,8 +39,11 @@ public:
                     LockType type) = 0;
   virtual void lock(const MemoryRecord& record, Device& device,
                     LockType type) = 0;
+  // For test purposes only
+  virtual void lock(const MemoryRecord& record, LockType type) = 0;
 
   virtual void release(const MemoryRecord& record, Device& device) = 0;
+  virtual void release(const MemoryRecord& record) = 0;
 
   template <typename BufferT>
   BufferT* get(const TensorInternal& tensor, Device& device) {

--- a/include/athena/backend/llvm/BackendAllocator.h
+++ b/include/athena/backend/llvm/BackendAllocator.h
@@ -24,6 +24,7 @@ namespace athena::backend::llvm {
 class BackendAllocator : public TensorAllocator {
 protected:
   virtual void* getImpl(const TensorInternal& tensor, Device& device) = 0;
+  virtual void* getImpl(const MemoryRecord& record, Device& device) = 0;
 
 public:
   virtual void registerDevice(Device& device) = 0;
@@ -31,20 +32,25 @@ public:
   /// Allocates memory on a particular device.
   virtual void allocate(const TensorInternal& tensor, Device& device) = 0;
   // fixme implement
-  virtual void allocate(const MemoryRecord& record, Device& device){};
+  virtual void allocate(const MemoryRecord& record, Device& device) = 0;
 
   /// Locks tensor raw memory on a particular device.
   virtual void lock(const TensorInternal& tensor, Device& device,
                     LockType type) = 0;
-  // fixme implement
   virtual void lock(const MemoryRecord& record, Device& device,
-                    LockType type){};
-  virtual void release(const MemoryRecord& record, Device& device){};
+                    LockType type) = 0;
+
+  virtual void release(const MemoryRecord& record, Device& device) = 0;
 
   template <typename BufferT>
   BufferT* get(const TensorInternal& tensor, Device& device) {
     return reinterpret_cast<BufferT*>(getImpl(tensor, device));
   }
+  template <typename BufferT>
+  BufferT* get(const MemoryRecord& record, Device& device) {
+    return reinterpret_cast<BufferT*>(getImpl(record, device));
+  }
+  virtual void* get(const MemoryRecord& record) = 0;
 };
 } // namespace athena::backend::llvm
 

--- a/include/athena/backend/llvm/LLVMExecutor.h
+++ b/include/athena/backend/llvm/LLVMExecutor.h
@@ -19,6 +19,7 @@
 #include <athena/core/graph/Traversal.h>
 #include <athena/core/internal/Executor.h>
 #include <athena/core/loader/internal/TensorAllocator.h>
+#include <athena/backend/llvm/runtime/Device.h>
 
 namespace athena::backend::llvm {
 
@@ -45,12 +46,20 @@ public:
   void evaluate(athena::core::Graph& graph) override;
 
   BackendAllocator& getAllocator();
-  void setAllocator(std::unique_ptr<BackendAllocator>& allocator);
+  std::shared_ptr<BackendAllocator> getAllocatorPtr();
+  void setAllocator(std::shared_ptr<BackendAllocator>& allocator);
+
+  std::vector<Device*>& getDevices();
+
+  void addModule(std::string_view module);
+
+  void execute(std::string_view name, void* userData);
 
 private:
   std::shared_ptr<AthenaJIT> mJITCompiler{nullptr};
-  std::unique_ptr<BackendAllocator> mAllocator;
+  std::shared_ptr<BackendAllocator> mAllocator;
   std::shared_ptr<RuntimeDriver> mRuntimeDriver;
+  std::vector<Device*> mDevices;
 };
 } // namespace athena::backend::llvm
 

--- a/include/athena/backend/llvm/runtime/GraphHandle.h
+++ b/include/athena/backend/llvm/runtime/GraphHandle.h
@@ -1,11 +1,15 @@
+#include <athena/backend/llvm/runtime/Device.h>
+
 #include <memory>
+#include <vector>
 
 #pragma once
 
 namespace athena::backend::llvm {
-  class BackendAllocator;
+class BackendAllocator;
 }
 
 struct GraphHandle {
   std::shared_ptr<athena::backend::llvm::BackendAllocator> allocator;
+  std::vector<athena::backend::llvm::Device*> devices;
 };

--- a/src/backend/llvm/CMakeLists.txt
+++ b/src/backend/llvm/CMakeLists.txt
@@ -89,12 +89,23 @@ llvm_map_components_to_libnames(llvm_libs
         AllTargetsInfos
         lto)
 
+if (APPLE)
+    set(WHOLE_ARCHIVE -Wl,-all_load)
+    set(NOWHOLE_ARCHIVE)
+elseif (UNIX)
+    set(WHOLE_ARCHIVE -Wl,--whole-archive)
+    set(NOWHOLE_ARCHIVE -Wl,--no-whole-archive)
+endif ()
+
 target_link_libraries(${ATH_BACKEND_LLVM} PRIVATE
         ${llvm_libs}
         ${AthenaJitTarget}
         MLIRIR
         MLIRStandardOps
-        MLIRAthenaGraph)
+        MLIRAthenaGraph
+        ${ATH_RT_LLVM_SUPPORT_OBJ}
+        ${ATH_RT_LLVM_DRIVER}
+        )
 target_include_directories(${ATH_BACKEND_LLVM} PRIVATE
         ${PROJECT_SOURCE_DIR}/utils/dialects/include
         ${PROJECT_BINARY_DIR}/utils/dialects/include)

--- a/src/backend/llvm/LLVMExecutor.cpp
+++ b/src/backend/llvm/LLVMExecutor.cpp
@@ -96,6 +96,7 @@ LLVMExecutor::LLVMExecutor() {
   for (auto dev : mRuntimeDriver->getDeviceList()) {
     dev->addModule(getOpenCLSPIRVProgram());
     dev->linkModules();
+    mAllocator->registerDevice(*dev);
   }
 }
 

--- a/src/backend/llvm/LLVMExecutor.cpp
+++ b/src/backend/llvm/LLVMExecutor.cpp
@@ -14,16 +14,28 @@
 #include "GraphPartitionPlanner.h"
 #include "allocators/LayerAllocator.h"
 #include "jit/AthenaJIT.h"
+#include "runtime/driver/RuntimeDriver.h"
+#include "ImageManager.h"
 
-#include <athena/backend/llvm/LLVMExecutor.h>
+#include "AthenaGraph/AthenaGraphDialect.h"
+#include "AthenaRuntime/AthenaRuntimeDialect.h"
 #include <athena/backend/llvm/CodeGen.h>
-#include <athena/core/graph/internal/GraphCompiler.h>
+#include <athena/backend/llvm/LLVMExecutor.h>
 #include <athena/core/Generator.h>
+#include <athena/core/graph/internal/GraphCompiler.h>
 #include <athena/utils/error/FatalError.h>
 
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Parser.h"
+#include "mlir/Pass/Pass.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/Support/Host.h"
-#include "mlir/IR/Builders.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/TargetSelect.h"
 
 #include <algorithm>
 
@@ -58,17 +70,60 @@ void LLVMExecutor::evaluate(Graph& graph) {
   evaluateFunction(nullptr);
 }
 
-LLVMExecutor::LLVMExecutor() : mJITCompiler(AthenaJIT::create()) {
+LLVMExecutor::LLVMExecutor() {
+  mlir::registerAllDialects();
+  mlir::registerAllPasses();
+
+  mlir::registerDialect<mlir::ath_graph::AthenaGraphDialect>();
+  mlir::registerDialect<mlir::ath_rt::AthenaRuntimeDialect>();
+
+  ::llvm::InitializeNativeTarget();
+  ::llvm::InitializeNativeTargetAsmPrinter();
+
+#ifdef DEBUG
+  mJITCompiler = AthenaJIT::createWithDebugging();
+#else
+  mJITCompiler = AthenaJIT::create();
+#endif
   if (!mJITCompiler) {
     new utils::FatalError(utils::ATH_FATAL_OTHER,
                           "Unable to create JIT compiler");
   }
 
-  mAllocator = std::make_unique<LayerAllocator>();
+  mAllocator = std::make_shared<LayerAllocator>();
+  mRuntimeDriver = std::make_shared<RuntimeDriver>();
+
+  for (auto dev : mRuntimeDriver->getDeviceList()) {
+    dev->addModule(getOpenCLSPIRVProgram());
+    dev->linkModules();
+  }
+}
+
+void LLVMExecutor::addModule(std::string_view module) {
+  auto moduleRef =
+      mlir::parseSourceString(module.data(), mJITCompiler->getContext());
+
+  mJITCompiler->addModule(moduleRef);
+}
+
+void LLVMExecutor::execute(std::string_view name, void* userData) {
+  auto sym = mJITCompiler->lookupSymbol(name.data());
+  utils::athena_assert((bool)sym, "Failed to find function.");
+
+  auto evaluateFunction = func_cast<void(void*)>(sym);
+  evaluateFunction(userData);
 }
 
 llvm::BackendAllocator& LLVMExecutor::getAllocator() { return *mAllocator; }
-void LLVMExecutor::setAllocator(std::unique_ptr<BackendAllocator>& allocator) {
+std::shared_ptr<BackendAllocator> LLVMExecutor::getAllocatorPtr() {
+  return mAllocator;
+}
+
+void LLVMExecutor::setAllocator(std::shared_ptr<BackendAllocator>& allocator) {
   mAllocator = std::move(allocator);
+}
+
+std::vector<Device*>& LLVMExecutor::getDevices() {
+  return mRuntimeDriver->getDeviceList();
 }
 } // namespace athena::backend::llvm

--- a/src/backend/llvm/allocators/LayerAllocator.cpp
+++ b/src/backend/llvm/allocators/LayerAllocator.cpp
@@ -24,6 +24,9 @@ void LayerAllocator::allocate(const core::internal::TensorInternal& tensor,
   MemoryRecord record{tensor.getVirtualAddress(),
                       tensor.getSize() *
                           core::sizeOfDataType(tensor.getDataType())};
+  allocate(record, device);
+}
+void LayerAllocator::allocate(const MemoryRecord& record, Device& device) {
   // Double allocation is noop.
   if (mDeviceAllocators[device.getDeviceName()]->isAllocated(record))
     return;
@@ -32,13 +35,18 @@ void LayerAllocator::allocate(const core::internal::TensorInternal& tensor,
   mLocks.insert({record, std::list<LockDescriptor>()});
   mMemTags[record] = 1;
 }
+
 void LayerAllocator::lock(const core::internal::TensorInternal& tensor,
                           Device& device, core::internal::LockType lockType) {
-  std::scoped_lock curLock{mMutex};
-
   MemoryRecord record{tensor.getVirtualAddress(),
                       tensor.getSize() *
                           core::sizeOfDataType(tensor.getDataType())};
+  lock(record, device, lockType);
+}
+
+void LayerAllocator::lock(const MemoryRecord& record, Device& device,
+                          core::internal::LockType lockType) {
+  std::scoped_lock curLock{mMutex};
 
   if (lockType == core::internal::LockType::READ_WRITE &&
       !mLocks[record].empty()) {
@@ -104,7 +112,7 @@ void LayerAllocator::deallocate(const core::internal::TensorInternal& tensor) {
                    record.virtualAddress);
   }
 
-  for (auto allocator : mDeviceAllocators) {
+  for (const auto& allocator : mDeviceAllocators) {
     if (allocator.second->isAllocated(record)) {
       allocator.second->deallocate(record);
     }
@@ -128,7 +136,9 @@ void* LayerAllocator::get(const core::internal::TensorInternal& tensor) {
   MemoryRecord record{tensor.getVirtualAddress(),
                       tensor.getSize() *
                           core::sizeOfDataType(tensor.getDataType())};
-
+  return get(record);
+}
+void* LayerAllocator::get(const MemoryRecord& record) {
   if (mRAMAllocator->isAllocated(record)) {
     return mRAMAllocator->getPtr(record);
   }
@@ -189,10 +199,14 @@ void LayerAllocator::release(const core::internal::TensorInternal& tensor) {
 }
 void* LayerAllocator::getImpl(const core::internal::TensorInternal& tensor,
                               Device& device) {
-  std::scoped_lock lock{mMutex};
   MemoryRecord record{tensor.getVirtualAddress(),
                       tensor.getSize() *
                           core::sizeOfDataType(tensor.getDataType())};
+
+  return getImpl(record, device);
+}
+void* LayerAllocator::getImpl(const MemoryRecord& record, Device& device) {
+  std::scoped_lock lock{mMutex};
 
   if (mDeviceAllocators[device.getDeviceName()]->isAllocated(record)) {
     return mDeviceAllocators[device.getDeviceName()]->getPtr(record);
@@ -244,11 +258,13 @@ void LayerAllocator::updateHost(MemoryRecord record) {
 }
 void LayerAllocator::release(const core::internal::TensorInternal& tensor,
                              Device& device) {
-  std::scoped_lock lock{mMutex};
-
   MemoryRecord record{tensor.getVirtualAddress(),
                       tensor.getSize() *
                           core::sizeOfDataType(tensor.getDataType())};
+  release(record, device);
+}
+void LayerAllocator::release(const MemoryRecord& record, Device& device) {
+  std::scoped_lock lock{mMutex};
 
   auto it = std::find_if(mLocks[record].begin(), mLocks[record].end(),
                          [&](const LockDescriptor& desc) {

--- a/src/backend/llvm/allocators/LayerAllocator.h
+++ b/src/backend/llvm/allocators/LayerAllocator.h
@@ -66,12 +66,6 @@ private:
 
   std::unordered_map<MemoryRecord, int> mMemTags;
 
-  //  std::unordered_map<MemoryRecord, MemoryDomain> mLockDomainMap;
-  //  // todo replace map with another structure to allow memory on multiple
-  //  devices std::unordered_map<MemoryRecord, Device*> mDeviceMap;
-  //  std::unordered_set<MemoryRecord> mRAMSet;
-  //  std::unordered_map<MemoryRecord, std::string> mSwapMap;
-
   void updateHost(MemoryRecord record);
 
 public:
@@ -81,6 +75,7 @@ public:
 
   void allocate(const core::internal::TensorInternal& tensor,
                 Device& device) override;
+  void allocate(const MemoryRecord& record, Device& device) override;
   void allocate(const core::internal::TensorInternal& tensor) override;
   void allocate(MemoryRecord record);
 
@@ -90,16 +85,21 @@ public:
             core::internal::LockType type) override;
   void lock(const core::internal::TensorInternal& tensor, Device& device,
             core::internal::LockType type) override;
+  void lock(const MemoryRecord& tensor, Device& device,
+            core::internal::LockType type) override;
 
   void release(const core::internal::TensorInternal& tensor) override;
   void release(const core::internal::TensorInternal& tensor, Device& device);
+  void release(const MemoryRecord& record, Device& device) override;
 
   void* get(const core::internal::TensorInternal& tensor) override;
+  void* get(const MemoryRecord& record) override;
   using BackendAllocator::get;
 
 protected:
   void* getImpl(const core::internal::TensorInternal& tensor,
                 Device& device) override;
+  void* getImpl(const MemoryRecord& record, Device& device) override;
 };
 } // namespace athena::backend::llvm
 

--- a/src/backend/llvm/allocators/LayerAllocator.h
+++ b/src/backend/llvm/allocators/LayerAllocator.h
@@ -83,12 +83,15 @@ public:
 
   void lock(const core::internal::TensorInternal& tensor,
             core::internal::LockType type) override;
+  void lock(const MemoryRecord& record,
+            core::internal::LockType type) override;
   void lock(const core::internal::TensorInternal& tensor, Device& device,
             core::internal::LockType type) override;
   void lock(const MemoryRecord& tensor, Device& device,
             core::internal::LockType type) override;
 
   void release(const core::internal::TensorInternal& tensor) override;
+  void release(const MemoryRecord& tensor) override;
   void release(const core::internal::TensorInternal& tensor, Device& device);
   void release(const MemoryRecord& record, Device& device) override;
 

--- a/src/backend/llvm/jit/AthenaJIT.cpp
+++ b/src/backend/llvm/jit/AthenaJIT.cpp
@@ -113,15 +113,12 @@ void AthenaJIT::compileModule() {
     ::llvm::errs() << "JIT error\n";
   }
 
-  mInternalModule->dump();
   auto llvmModule = mlir::LLVM::ModuleTranslation::translateModule(
       mInternalModule->getOperation());
 
   std::unique_ptr<LLVMContext> llvmCtx = std::make_unique<LLVMContext>();
   auto newModule =
       mlir::LLVM::cloneModuleIntoNewContext(llvmCtx.get(), llvmModule.get());
-
-  newModule->print(::llvm::dbgs(), nullptr);
 
   ThreadSafeModule tsm(std::move(newModule), std::move(llvmCtx));
   auto err = mJITInstance->addIRModule(std::move(tsm));

--- a/src/backend/llvm/jit/AthenaJIT.cpp
+++ b/src/backend/llvm/jit/AthenaJIT.cpp
@@ -113,6 +113,7 @@ void AthenaJIT::compileModule() {
     ::llvm::errs() << "JIT error\n";
   }
 
+  mInternalModule->dump();
   auto llvmModule = mlir::LLVM::ModuleTranslation::translateModule(
       mInternalModule->getOperation());
 

--- a/src/backend/llvm/jit/AthenaJIT.cpp
+++ b/src/backend/llvm/jit/AthenaJIT.cpp
@@ -19,6 +19,10 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/SectionMemoryManager.h"
+#include "llvm/ExecutionEngine/JITEventListener.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 
 using namespace ::llvm;
 using namespace ::llvm::orc;
@@ -30,13 +34,40 @@ AthenaJIT::AthenaJIT(std::unique_ptr<::llvm::orc::LLJIT> jit)
     : mJITInstance(std::move(jit)), mMlirPassManager(&mContext) {
   setupMlirPassManager();
 };
+
 auto AthenaJIT::create() -> std::shared_ptr<AthenaJIT> {
   ::llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
   auto JIT = ExitOnErr(LLJITBuilder().create());
   JIT->getMainJITDylib().addGenerator(
-      ::llvm::cantFail(
-          ::llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
-              JIT->getDataLayout().getGlobalPrefix())));
+      cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(
+          JIT->getDataLayout().getGlobalPrefix())));
+
+  return std::make_shared<AthenaJIT>(std::move(JIT));
+}
+
+auto AthenaJIT::createWithDebugging() -> std::shared_ptr<AthenaJIT> {
+  ::llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
+  auto objectLinkingLayerCreator = [](ExecutionSession& ES, const Triple& TT) {
+    auto GetMemMgr = []() { return std::make_unique<SectionMemoryManager>(); };
+    auto ObjLinkingLayer =
+        std::make_unique<RTDyldObjectLinkingLayer>(ES, std::move(GetMemMgr));
+
+    // Register the event listener.
+    ObjLinkingLayer->registerJITEventListener(
+        *JITEventListener::createGDBRegistrationListener());
+
+    // Make sure the debug info sections aren't stripped.
+    ObjLinkingLayer->setProcessAllSections(true);
+
+    return ObjLinkingLayer;
+  };
+  auto JIT =
+      ExitOnErr(LLJITBuilder()
+                    .setObjectLinkingLayerCreator(objectLinkingLayerCreator)
+                    .create());
+  JIT->getMainJITDylib().addGenerator(::llvm::cantFail(
+      ::llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
+          JIT->getDataLayout().getGlobalPrefix())));
 
   return std::make_shared<AthenaJIT>(std::move(JIT));
 }
@@ -88,6 +119,8 @@ void AthenaJIT::compileModule() {
   std::unique_ptr<LLVMContext> llvmCtx = std::make_unique<LLVMContext>();
   auto newModule =
       mlir::LLVM::cloneModuleIntoNewContext(llvmCtx.get(), llvmModule.get());
+
+  newModule->print(::llvm::dbgs(), nullptr);
 
   ThreadSafeModule tsm(std::move(newModule), std::move(llvmCtx));
   auto err = mJITInstance->addIRModule(std::move(tsm));

--- a/src/backend/llvm/jit/AthenaJIT.h
+++ b/src/backend/llvm/jit/AthenaJIT.h
@@ -8,6 +8,7 @@ public:
   AthenaJIT(std::unique_ptr<::llvm::orc::LLJIT> jit);
 
   static auto create() -> std::shared_ptr<AthenaJIT>;
+  static auto createWithDebugging() -> std::shared_ptr<AthenaJIT>;
 
   void addModule(const mlir::OwningModuleRef& ref);
   auto lookupSymbol(::llvm::StringRef symbolName) -> ::llvm::JITTargetAddress;

--- a/src/backend/llvm/runtime/support/CMakeLists.txt
+++ b/src/backend/llvm/runtime/support/CMakeLists.txt
@@ -1,8 +1,14 @@
 set(ATH_RT_LLVM_SUPPORT "AthenaLLVMSupport" CACHE STRING "" FORCE)
-add_athena_library(${ATH_RT_LLVM_SUPPORT} STATIC 
+set(ATH_RT_LLVM_SUPPORT_OBJ "AthenaLLVMSupportObj" CACHE STRING "" FORCE)
+add_athena_library(${ATH_RT_LLVM_SUPPORT_OBJ} OBJECT 
         ATH_RT_SUPPORT # export name
         backend/llvm/runtime/support/export.h # export file name
         routines.cpp)
+
+add_athena_library(${ATH_RT_LLVM_SUPPORT} STATIC 
+        ATH_RT_SUPPORT # export name
+        backend/llvm/runtime/support/export.h # export file name
+        $<TARGET_OBJECTS:${ATH_RT_LLVM_SUPPORT_OBJ}>)
 
 install(TARGETS ${ATH_RT_LLVM_SUPPORT} EXPORT AthenaConfig
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/backend/llvm/runtime/support/routines.cpp
+++ b/src/backend/llvm/runtime/support/routines.cpp
@@ -1,3 +1,5 @@
+#include "../utils/utils.h"
+
 #include <athena/backend/llvm/BackendAllocator.h>
 #include <athena/backend/llvm/runtime/Device.h>
 #include <athena/backend/llvm/runtime/Event.h>
@@ -10,16 +12,6 @@
 
 using namespace athena::backend::llvm;
 
-static MemoryRecord tensorInfoToRecord(TensorInfo* tensor) {
-  MemoryRecord record;
-  record.virtualAddress = tensor->virtAddr;
-  record.allocationSize = athena::core::sizeOfDataType(
-      static_cast<athena::core::DataType>(tensor->dataType));
-  for (int i = 0; i < tensor->dims; i++) {
-    record.allocationSize *= tensor->shape[i];
-  }
-  return record;
-}
 
 extern "C" {
 
@@ -51,7 +43,6 @@ ATH_RT_SUPPORT_EXPORT void ath_barrier(uint32_t count, Event** events) {}
 
 ATH_RT_SUPPORT_EXPORT Event* ath_launch(GraphHandle* handle, Device* device,
                                         Event* event, LaunchCommand& command) {
-  std::cerr << device->getDeviceName() << "\n";
   return device->launch(*handle->allocator, command, event);
 }
 }

--- a/src/backend/llvm/runtime/support/routines.cpp
+++ b/src/backend/llvm/runtime/support/routines.cpp
@@ -6,6 +6,8 @@
 #include <athena/backend/llvm/runtime/TensorInfo.h>
 #include <athena/backend/llvm/runtime/support/export.h>
 
+#include <iostream>
+
 using namespace athena::backend::llvm;
 
 static MemoryRecord tensorInfoToRecord(TensorInfo* tensor) {
@@ -42,12 +44,14 @@ ath_lock(GraphHandle* handle, Device& device, TensorInfo* tensor,
 
 ATH_RT_SUPPORT_EXPORT Device* ath_device_select(GraphHandle* handle,
                                                 uint64_t nodeId) {
-  return nullptr;
+  return handle->devices.front(); // TODO real device selection logic.
 }
 
-ATH_RT_SUPPORT_EXPORT Event* ath_launch(Device& device,
-                                        BackendAllocator& allocator,
+ATH_RT_SUPPORT_EXPORT void ath_barrier(uint32_t count, Event** events) {}
+
+ATH_RT_SUPPORT_EXPORT Event* ath_launch(GraphHandle* handle, Device* device,
                                         Event* event, LaunchCommand& command) {
-  return device.launch(allocator, command, event);
+  std::cerr << device->getDeviceName() << "\n";
+  return device->launch(*handle->allocator, command, event);
 }
 }

--- a/src/backend/llvm/runtime/utils/utils.h
+++ b/src/backend/llvm/runtime/utils/utils.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <athena/backend/llvm/BackendAllocator.h>
+#include <athena/backend/llvm/runtime/TensorInfo.h>
+
+inline auto tensorInfoToRecord(TensorInfo* tensor)
+    -> athena::backend::llvm::MemoryRecord {
+  athena::backend::llvm::MemoryRecord record;
+  record.virtualAddress = tensor->virtAddr;
+  record.allocationSize = athena::core::sizeOfDataType(
+      static_cast<athena::core::DataType>(tensor->dataType));
+  for (int i = 0; i < tensor->dims; i++) {
+    record.allocationSize *= tensor->shape[i];
+  }
+  return record;
+}

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -2,3 +2,4 @@ add_subdirectory(framework)
 
 include(AthenaIntegrationTest)
 add_subdirectory(OpenCLRuntime)
+add_subdirectory(JIT)

--- a/tests/integration/JIT/CMakeLists.txt
+++ b/tests/integration/JIT/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(INT_TEST_SRC
+  main.cpp)
+
+add_athena_executable(
+        TestIntegrationJITRunnable
+        ${INT_TEST_SRC})
+
+target_link_libraries(TestIntegrationJITRunnable PRIVATE
+        athena
+        AthenaDep::googletest)
+
+add_test(NAME JITIntegrationTest COMMAND TestIntegrationJITRunnable)

--- a/tests/integration/JIT/CMakeLists.txt
+++ b/tests/integration/JIT/CMakeLists.txt
@@ -5,8 +5,10 @@ add_athena_executable(
         TestIntegrationJITRunnable
         ${INT_TEST_SRC})
 
+find_package(Threads)
 target_link_libraries(TestIntegrationJITRunnable PRIVATE
         athena
-        AthenaDep::googletest)
+        AthenaDep::googletest
+        Threads::Threads)
 
 add_test(NAME JITIntegrationTest COMMAND TestIntegrationJITRunnable)

--- a/tests/integration/JIT/main.cpp
+++ b/tests/integration/JIT/main.cpp
@@ -1,0 +1,36 @@
+#include <athena/backend/llvm/LLVMExecutor.h>
+#include <athena/backend/llvm/runtime/GraphHandle.h>
+
+#include <gtest/gtest.h>
+
+using namespace athena::backend::llvm;
+
+constexpr static auto IR = R"(
+module {
+  "ath_graph.node"() ( {
+    %0 = "ath_graph.create_tensor"() {virtual_address = 1 : index} : () -> tensor<3xf32>
+    "ath_graph.alloc"(%0) : (tensor<3xf32>) -> ()
+    "ath_graph.lock"(%0) {lock_type = "read_write"} : (tensor<3xf32>) -> ()
+    %1 = constant 42.0 : f32
+    %2 = "ath_graph.fill"(%1, %0) : (f32, tensor<3xf32>) -> (tensor<3xf32>)
+    "ath_graph.release"(%0) : (tensor<3xf32>) -> ()
+    "ath_graph.return"(%2) : (tensor<3xf32>) -> ()
+  }) {cluster_id = 0 : index, node_id = 0 : index, sym_name = "testNode", type = () -> tensor<3xf32>} : () -> ()
+  "ath_graph.graph"() ( {
+    %0 = "ath_graph.eval"() {node = @testNode} : () -> tensor<3xf32>
+    "ath_graph.barrier"() {clusterId = 0 : index} : () -> ()
+    "ath_graph.graph_terminator"() : () -> ()
+  }) {sym_name = "testGraph", type = () -> ()} : () -> ()
+}
+)";
+
+TEST(JITIntegration, FillOperationSample) {
+  LLVMExecutor executor;
+  executor.addModule(IR);
+
+  GraphHandle handle;
+  handle.allocator = executor.getAllocatorPtr();
+  handle.devices = executor.getDevices();
+
+  executor.execute("testGraph", &handle);
+}

--- a/tests/integration/JIT/main.cpp
+++ b/tests/integration/JIT/main.cpp
@@ -8,16 +8,16 @@ using namespace athena::backend::llvm;
 constexpr static auto IR = R"(
 module {
   "ath_graph.node"() ( {
-    %0 = "ath_graph.create_tensor"() {virtual_address = 1 : index} : () -> tensor<3xf32>
-    "ath_graph.alloc"(%0) : (tensor<3xf32>) -> ()
-    "ath_graph.lock"(%0) {lock_type = "read_write"} : (tensor<3xf32>) -> ()
+    %0 = "ath_graph.create_tensor"() {virtual_address = 1 : index} : () -> tensor<32xf32>
+    "ath_graph.alloc"(%0) : (tensor<32xf32>) -> ()
+    "ath_graph.lock"(%0) {lock_type = "read_write"} : (tensor<32xf32>) -> ()
     %1 = constant 42.0 : f32
-    %2 = "ath_graph.fill"(%1, %0) : (f32, tensor<3xf32>) -> (tensor<3xf32>)
-    "ath_graph.release"(%0) : (tensor<3xf32>) -> ()
-    "ath_graph.return"(%2) : (tensor<3xf32>) -> ()
+    %2 = "ath_graph.fill"(%1, %0) : (f32, tensor<32xf32>) -> (tensor<32xf32>)
+    "ath_graph.release"(%0) : (tensor<32xf32>) -> ()
+    "ath_graph.return"(%2) : (tensor<32xf32>) -> ()
   }) {cluster_id = 0 : index, node_id = 0 : index, sym_name = "testNode", type = () -> tensor<3xf32>} : () -> ()
   "ath_graph.graph"() ( {
-    %0 = "ath_graph.eval"() {node = @testNode} : () -> tensor<3xf32>
+    %0 = "ath_graph.eval"() {node = @testNode} : () -> tensor<32xf32>
     "ath_graph.barrier"() {clusterId = 0 : index} : () -> ()
     "ath_graph.graph_terminator"() : () -> ()
   }) {sym_name = "testGraph", type = () -> ()} : () -> ()

--- a/tests/integration/JIT/main.cpp
+++ b/tests/integration/JIT/main.cpp
@@ -24,7 +24,7 @@ module {
 }
 )";
 
-TEST(JITIntegration, FillOperationSample) {
+TEST(JITIntegration, DISABLED_FillOperationSample) {
   LLVMExecutor executor;
   executor.addModule(IR);
 
@@ -33,4 +33,16 @@ TEST(JITIntegration, FillOperationSample) {
   handle.devices = executor.getDevices();
 
   executor.execute("testGraph", &handle);
+
+  auto& allocator = executor.getAllocator();
+
+  MemoryRecord record;
+  record.virtualAddress = 1;
+  record.allocationSize = 32 * 4;
+  allocator.lock(record, LockType::READ);
+  auto data = static_cast<float*>(allocator.get(record));
+  for (int i = 0; i < 32; i++) {
+    EXPECT_FLOAT_EQ(data[i], 42.0f);
+  }
+  allocator.release(record);
 }

--- a/utils/dialects/include/AthenaGraph/AthenaGraphOps.td
+++ b/utils/dialects/include/AthenaGraph/AthenaGraphOps.td
@@ -289,7 +289,7 @@ def AthenaGraph_TransposeOp : AthenaGraph_Op<"transpose", [Computational]> {
   }]>];
 }
 
-def AthenaGraph_FillOp : AthenaGraph_Op<"fill", [Computational]> {
+def AthenaGraph_FillOp : AthenaGraph_Op<"fill", [ComputationalOpInterface]> {
   let summary = "Fills tensor with value";
   let description = [{ TBD }];
 
@@ -301,6 +301,11 @@ def AthenaGraph_FillOp : AthenaGraph_Op<"fill", [Computational]> {
     result.addOperands(out);
     result.types.push_back(out.getType());
   }]>];
+  let extraClassDeclaration = [{
+    llvm::StringRef getKernelName() {
+      return "ffill";
+    }
+  }];
 }
 
 #endif // ATHENA_GRAPH_OPS

--- a/utils/dialects/lib/Conversion/GraphToRuntimePass.cpp
+++ b/utils/dialects/lib/Conversion/GraphToRuntimePass.cpp
@@ -78,8 +78,9 @@ struct BuiltinConversionPattern : public AthenaGraphConversionPattern<OpT> {
     // FIXME this pattern is incorrect if node performs more than one
     //       computation.
     auto launchOp = rewriter.create<ath_rt::LaunchOp>(
-        op->getLoc(), resTypes, device, blockingEvent, "dummy", globalSize,
-        localSize, operands);
+        op->getLoc(), resTypes, device, blockingEvent,
+        concreteOp.getKernelName(), globalSize, localSize, operands);
+    launchOp.dump();
     rewriter.replaceOp(op, launchOp.getResult(0));
     return success();
   }
@@ -350,7 +351,7 @@ protected:
 namespace mlir {
 void populateGraphToRuntimeConversionPatterns(
     OwningRewritePatternList& loweringPatterns, MLIRContext* ctx) {
-  loweringPatterns.insert <
+  loweringPatterns.insert<
       // clang-format off
       GraphOpConversionPattern,
       NodeOpConversionPattern,

--- a/utils/dialects/lib/Conversion/GraphToRuntimePass.cpp
+++ b/utils/dialects/lib/Conversion/GraphToRuntimePass.cpp
@@ -80,7 +80,6 @@ struct BuiltinConversionPattern : public AthenaGraphConversionPattern<OpT> {
     auto launchOp = rewriter.create<ath_rt::LaunchOp>(
         op->getLoc(), resTypes, device, blockingEvent,
         concreteOp.getKernelName(), globalSize, localSize, operands);
-    launchOp.dump();
     rewriter.replaceOp(op, launchOp.getResult(0));
     return success();
   }

--- a/utils/dialects/lib/Conversion/RuntimeToLLVM.cpp
+++ b/utils/dialects/lib/Conversion/RuntimeToLLVM.cpp
@@ -405,7 +405,6 @@ struct LaunchOpLoweringPattern
     auto argsOperands =
         llvm::iterator_range(operands.begin() + 2, operands.end());
     for (auto operand : llvm::enumerate(argsOperands)) {
-      // auto zero = createUInt64Constant(0, llvmDialect, rewriter, op->getLoc());
       auto idx = createUInt64Constant(operand.index(), llvmDialect, rewriter,
                                       op->getLoc());
       auto argDesc = rewriter.create<LLVM::GEPOp>(
@@ -432,9 +431,6 @@ struct LaunchOpLoweringPattern
         auto sizeInBytes = createUInt64Constant(
             llvmType.getUnderlyingType()->getScalarSizeInBits() / 8,
             llvmDialect, rewriter, op->getLoc());
-        ::llvm::errs() << llvmType.getUnderlyingType()->getScalarSizeInBits() /
-                              8
-                       << "\n";
         setStructFieldTo(argDesc, getArgDescType(llvmDialect), sizeInBytes, 0,
                          rewriter, op->getLoc());
 

--- a/utils/dialects/lib/Conversion/RuntimeToLLVM.cpp
+++ b/utils/dialects/lib/Conversion/RuntimeToLLVM.cpp
@@ -400,10 +400,10 @@ struct LaunchOpLoweringPattern
     concreteOp.getResult(0).replaceAllUsesWith(operands.back());
 
     auto argsArray = createArray(getArgDescType(llvmDialect).getPointerTo(),
-                                 operands.size() - 3, rewriter, op->getLoc());
+                                 operands.size() - 2, rewriter, op->getLoc());
 
     auto argsOperands =
-        llvm::iterator_range(operands.begin() + 3, operands.end());
+        llvm::iterator_range(operands.begin() + 2, operands.end());
     for (auto operand : llvm::enumerate(argsOperands)) {
       auto argDesc = allocateStructure(getArgDescType(llvmDialect), rewriter,
                                        op->getLoc());
@@ -425,6 +425,7 @@ struct LaunchOpLoweringPattern
         auto sizeInBytes = createUInt64Constant(
             llvmType.getUnderlyingType()->getScalarSizeInBits() / 8,
             llvmDialect, rewriter, op->getLoc());
+        ::llvm::errs() << llvmType.getUnderlyingType()->getScalarSizeInBits() / 8 << "\n";
         setStructFieldTo(argDesc, getArgDescType(llvmDialect), sizeInBytes, 0,
                          rewriter, op->getLoc());
 
@@ -475,7 +476,7 @@ struct LaunchOpLoweringPattern
                      kerNamePtr, 0, rewriter, op->getLoc());
 
     // Set kernel arg count
-    auto argCount = createUInt64Constant(operands.size() - 3, llvmDialect,
+    auto argCount = createUInt64Constant(operands.size() - 2, llvmDialect,
                                          rewriter, op->getLoc());
     setStructFieldTo(launchCommand, getLaunchCommandType(llvmDialect), argCount,
                      1, rewriter, op->getLoc());

--- a/utils/dialects/lib/utils/LaunchCommand.h
+++ b/utils/dialects/lib/utils/LaunchCommand.h
@@ -35,7 +35,7 @@ getLaunchCommandType(mlir::LLVM::LLVMDialect* llvmDialect) {
   LLVM::LLVMType argDescTy = getArgDescType(llvmDialect);
   auto kernelNameTy = LLVM::LLVMType::getInt8Ty(llvmDialect).getPointerTo();
   auto argsCountTy = LLVM::LLVMType::getInt64Ty(llvmDialect);
-  auto argsTy = argDescTy.getPointerTo().getPointerTo();
+  auto argsTy = argDescTy.getPointerTo();
   auto workDimTy = LLVM::LLVMType::getInt64Ty(llvmDialect);
   auto dimSizeTy =
       LLVM::LLVMType::getInt64Ty(llvmDialect).getPointerTo();


### PR DESCRIPTION
Multiple bugs in the LLVM backend:
- Wrong data layout for ArgDesc structure in IR
- Incorrect arguments type in IR
- Incorrect local size in OpenCL runtime
- Incorrect tensor argument handling in OpenCL runtime
- Incorrect routines implementation in support library
- Missing implementations in LayerAllocator