### PR TITLE
feat: basic Compute dialect outlining

### DIFF
--- a/utils/dialects/include/CMakeLists.txt
+++ b/utils/dialects/include/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(AthenaGraph)
 add_subdirectory(AthenaRuntime)
+add_subdirectory(Compute)

--- a/utils/dialects/include/Compute/CMakeLists.txt
+++ b/utils/dialects/include/Compute/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_mlir_dialect(ComputeOps compute)
+add_mlir_doc(ComputeDialect -gen-dialect-doc ComputeDialect Compute/)
+add_mlir_doc(ComputeOps -gen-op-doc ComputeOps Compute/)

--- a/utils/dialects/include/Compute/ComputeDialect.h
+++ b/utils/dialects/include/Compute/ComputeDialect.h
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_EXTRAS_COMPUTEDIALECT_H
+#define CLANG_EXTRAS_COMPUTEDIALECT_H
+
+#include "mlir/IR/Dialect.h"
+
+namespace mlir::compute {
+
+#include "Compute/ComputeOpsDialect.h.inc"
+}
+
+#endif // CLANG_EXTRAS_COMPUTEDIALECT_H

--- a/utils/dialects/include/Compute/ComputeDialect.td
+++ b/utils/dialects/include/Compute/ComputeDialect.td
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#ifndef COMPUTE_DIALECT
+#define COMPUTE_DIALECT
+
+include "mlir/IR/OpBase.td"
+
+def Compute_Dialect : Dialect {
+    let name = "compute";
+    let cppNamespace = "compute";
+}
+
+class Compute_Op<string mnemonic, list <OpTrait> traits = []> 
+        : Op<Compute_Dialect, mnemonic, traits>;
+
+#endif // COMPUTE_DIALECT

--- a/utils/dialects/include/Compute/ComputeOps.h
+++ b/utils/dialects/include/Compute/ComputeOps.h
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_EXTRAS_COMPUTEOPS_H
+#define CLANG_EXTRAS_COMPUTEOPS_H
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/FunctionSupport.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffects.h"
+
+namespace mlir::compute {
+#define GET_OP_CLASSES
+#include "Compute/ComputeOps.h.inc"
+} // namespace mlir::clang
+
+#endif // CLANG_EXTRAS_COMPUTEOPS_H

--- a/utils/dialects/include/Compute/ComputeOps.td
+++ b/utils/dialects/include/Compute/ComputeOps.td
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+include "Compute/ComputeDialect.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffects.td"
+
+def Compute_ModuleOp : Compute_Op<"module", [IsolatedFromAbove, SymbolTable, Symbol,
+                                             SingleBlockImplicitTerminator<"ModuleEndOp">]> {
+  let summary = "A top level compilation unit for offload code";
+  let description = [{
+    TBD
+  }];
+
+  let builders = [OpBuilder<"OpBuilder& builder, OperationState &result, "
+                            "StringRef name">];
+
+  let regions = (region SizedRegion<1>:$body);
+  let skipDefaultBuilders = 1;
+}
+
+def Compute_ModuleEndOp : Compute_Op<"module_end", [Terminator, HasParent<"ModuleOp">]> {
+  let summary = "A pseudo operation that marks end of a compute.module";
+  let description = [{
+    TBD
+  }];
+
+  let parser = [{ return success(); }];
+  let printer = [{ p << getOperationName(); }];
+}
+
+def Compute_FuncOp : Compute_Op<"func", [HasParent<"ModuleOp">, AutomaticAllocationScope,
+                                         FunctionLike, IsolatedFromAbove, Symbol]> {
+  let summary = "A callable routine (either kernel or a free function)";
+  // todo extend description with samples when dialect is formed.
+  let description = [{
+    TBD
+  }];
+
+  let regions = (region AnyRegion:$body);
+
+  let skipDefaultBuilders = 1;
+
+  let builders = [
+    OpBuilder<"OpBuilder& builder, OperationState &result, StringRef name, FunctionType type, "
+              "ArrayRef<NamedAttribute> attrs = {}">
+  ];
+
+  let extraClassDeclaration = [{
+    friend class OpTrait::FunctionLike<FuncOp>;
+    unsigned getNumFuncArguments() { return getType().getNumInputs(); }
+    unsigned getNumFuncResults() { return getType().getNumResults(); }
+    static StringRef getKernelAttributeName() {
+      return "kernel";
+    }
+  }];
+
+  // todo custom verifier and custom parser
+}
+
+def Compute_ReturnOp : Compute_Op<"return", [HasParent<"FuncOp">, NoSideEffect, Terminator]> {
+  let summary = "Terminator for Compute functions";
+  let description = [{
+    TBD
+  }];
+
+  // todo custom printer, parser, verifier
+}
+
+//===----------------------------------------------------------------------===//
+// Dimension operations
+//===----------------------------------------------------------------------===//
+
+def Compute_GlobalIdOp : Compute_Op<"global_id", [NoSideEffect]> {
+  let summary = "Return global id of current work-item in ND-range";
+  let description = [{
+    TBD
+  }];
+
+  let arguments = (ins IndexAttr:$dim);
+  let results = (outs Index);
+}
+
+def Compute_GlobalSizeOp : Compute_Op<"global_size", [NoSideEffect]> {
+  let summary = "Return global size of dimension in ND-range";
+  let description = [{
+    TBD
+  }];
+
+  let arguments = (ins IndexAttr:$dim);
+  let results = (outs Index);
+}
+
+def Compute_LocalIdOp : Compute_Op<"local_id", [NoSideEffect]> {
+  let summary = "Return local id of current work-item in work-group";
+  let description = [{
+    TBD
+  }];
+
+  let arguments = (ins IndexAttr:$dim);
+  let results = (outs Index);
+}
+
+def Compute_LocalSizeOp : Compute_Op<"local_size", [NoSideEffect]> {
+  let summary = "Return global size of dimension in work-group";
+  let description = [{
+    TBD
+  }];
+
+  let arguments = (ins IndexAttr:$dim);
+  let results = (outs Index);
+}

--- a/utils/dialects/include/Conversion/ComputeToSPIRVPass.h
+++ b/utils/dialects/include/Conversion/ComputeToSPIRVPass.h
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#ifndef ATHENA_COMPUTETOOPENCLSPIRVPASS_H
+#define ATHENA_COMPUTETOOPENCLSPIRVPASS_H
+
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include <memory>
+
+namespace mlir {
+// Forward declaration
+class SPIRVTypeConverter;
+class ModuleOp;
+template <typename T> class OperationPass;
+
+void populateComputeToOpenCLSPIRVPatterns(MLIRContext* context,
+                                          SPIRVTypeConverter& typeConverter,
+                                          OwningRewritePatternList& patterns);
+
+auto createConvertComputeToOpenCLSPIRVPass()
+    -> std::unique_ptr<OperationPass<ModuleOp>>;
+} // namespace mlir
+
+#endif // ATHENA_COMPUTETOOPENCLSPIRVPASS_H

--- a/utils/dialects/lib/CMakeLists.txt
+++ b/utils/dialects/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(AthenaGraph)
 add_subdirectory(AthenaRuntime)
+add_subdirectory(Compute)
 add_subdirectory(Conversion)
 add_subdirectory(Passes)

--- a/utils/dialects/lib/Compute/CMakeLists.txt
+++ b/utils/dialects/lib/Compute/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_mlir_dialect_library(MLIRCompute
+        ComputeDialect.cpp
+        ComputeOps.cpp
+        ADDITIONAL_HEADER_DIRS
+        ${PROJECT_SOURCE_DIR}/dialects/include
+
+        DEPENDS
+        MLIRComputeOpsIncGen
+
+        LINK_LIBS PUBLIC
+        MLIREDSC
+        MLIRIR
+        MLIRSideEffects
+        MLIRStandardOps
+        MLIRSupport
+        MLIRTransformUtils
+        )

--- a/utils/dialects/lib/Compute/ComputeDialect.cpp
+++ b/utils/dialects/lib/Compute/ComputeDialect.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#include "Compute/ComputeDialect.h"
+#include "Compute/ComputeOps.h"
+
+using namespace mlir;
+using namespace mlir::compute;
+
+ComputeDialect::ComputeDialect(::mlir::MLIRContext *context) : ::mlir::Dialect(getDialectNamespace(), context) {
+  addOperations<
+#define GET_OP_LIST
+#include "Compute/ComputeOps.cpp.inc"
+      >();
+}

--- a/utils/dialects/lib/Compute/ComputeOps.cpp
+++ b/utils/dialects/lib/Compute/ComputeOps.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#include "Compute/ComputeOps.h"
+#include "Compute/ComputeDialect.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Function.h"
+#include "mlir/IR/FunctionImplementation.h"
+#include "mlir/IR/Module.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/StandardTypes.h"
+
+using namespace mlir;
+using namespace mlir::compute;
+
+void compute::ModuleOp::build(OpBuilder& builder, OperationState &result, StringRef name) {
+  ensureTerminator(*result.addRegion(), builder, result.location);
+  result.attributes.push_back(builder.getNamedAttr(
+      ::mlir::SymbolTable::getSymbolAttrName(), builder.getStringAttr(name)));
+}
+void compute::FuncOp::build(OpBuilder& builder, OperationState &result,
+                            StringRef name, FunctionType type,
+                            ArrayRef<NamedAttribute> attrs) {
+  result.addAttribute(SymbolTable::getSymbolAttrName(),
+                      builder.getStringAttr(name));
+  result.addAttribute(getTypeAttrName(), TypeAttr::get(type));
+  result.addAttributes(attrs);
+  Region *body = result.addRegion();
+  auto *entryBlock = new Block;
+  entryBlock->addArguments(type.getInputs());
+
+  body->getBlocks().push_back(entryBlock);
+}
+
+namespace mlir::compute {
+#define GET_OP_CLASSES
+#include "Compute/ComputeOps.cpp.inc"
+} // namespace mlir::compute

--- a/utils/dialects/lib/Conversion/CMakeLists.txt
+++ b/utils/dialects/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(ComputeToSPIRV)
+
 add_mlir_conversion_library(MLIRAthenaConversion
         GraphToRuntimePass.cpp
         ArgInfo.cpp

--- a/utils/dialects/lib/Conversion/ComputeToSPIRV/CMakeLists.txt
+++ b/utils/dialects/lib/Conversion/ComputeToSPIRV/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(LLVM_TARGET_DEFINITIONS ComputeToSPIRV.td)
+mlir_tablegen(ComputeToSPIRV.cpp.inc -gen-rewriters)
+add_public_tablegen_target(MLIRComputeToSPIRVIncGen)
+include_directories(
+        ${PROJECT_BINARY_DIR}/lib/Conversion/ComputeToSPIRV/
+)
+add_mlir_conversion_library(MLIRComputeToSPIRV
+        ComputeToOpenCLSPIRV.cpp
+
+        ADDITIONAL_HEADER_DIRS
+        ${PROJECT_SOURCE_DIR}/include/
+        ${PROJECT_BINARY_DIR}/lib/Conversion/ComputeToSPIRV/
+
+        DEPENDS
+        MLIRCompute
+        MLIRComputeToSPIRVIncGen
+        )
+
+target_include_directories(MLIRComputeToSPIRV PUBLIC ${PROJECT_BINARY_DIR}/lib/Conversion/ComputeToSPIRV/)
+message(STATUS ${PROJECT_BINARY_DIR}/lib/Conversion/ComputeToSPIRV/)
+
+target_link_libraries(MLIRComputeToSPIRV
+        PUBLIC
+        MLIRIR
+        MLIRPass
+        MLIRCompute
+        MLIRTransforms
+        MLIRSPIRV
+        MLIRGPU
+        MLIRSupport
+        MLIRStandardToSPIRVTransforms
+        MLIRStandardOps
+        LLVMSupport
+        MLIRSupport
+        )

--- a/utils/dialects/lib/Conversion/ComputeToSPIRV/ComputeToOpenCLSPIRV.cpp
+++ b/utils/dialects/lib/Conversion/ComputeToSPIRV/ComputeToOpenCLSPIRV.cpp
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 Athena. All rights reserved.
+// https://getathena.ml
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#include "Compute/ComputeOps.h"
+#include "Conversion/ComputeToSPIRVPass.h"
+
+#include "mlir/Conversion/GPUToSPIRV/ConvertGPUToSPIRV.h"
+#include "mlir/Conversion/StandardToSPIRV/ConvertStandardToSPIRV.h"
+#include "mlir/Dialect/SPIRV/SPIRVDialect.h"
+#include "mlir/Dialect/SPIRV/SPIRVLowering.h"
+#include "mlir/Dialect/SPIRV/SPIRVOps.h"
+#include "mlir/IR/Module.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
+namespace {
+class ComputeFuncOpLowering : public SPIRVOpLowering<compute::FuncOp> {
+public:
+  using SPIRVOpLowering<compute::FuncOp>::SPIRVOpLowering;
+
+  LogicalResult
+  matchAndRewrite(compute::FuncOp funcOp, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    // fixme check for kernel
+
+    SmallVector<spirv::InterfaceVarABIAttr, 4> argABI;
+    for (auto argIndex : llvm::seq<unsigned>(0, funcOp.getNumArguments())) {
+      Optional<spirv::StorageClass> sc;
+      if (funcOp.getArgument(argIndex).getType().isIntOrIndexOrFloat())
+        sc = spirv::StorageClass::StorageBuffer;
+      argABI.push_back(spirv::getInterfaceVarABIAttr(0, argIndex, sc,
+                                                     rewriter.getContext()));
+    }
+
+    auto fnType = funcOp.getType();
+
+    TypeConverter::SignatureConversion signatureConverter(
+        fnType.getNumInputs());
+    {
+      for (auto argType : enumerate(funcOp.getType().getInputs())) {
+        auto convertedType = typeConverter.convertType(argType.value());
+        signatureConverter.addInputs(argType.index(), convertedType);
+      }
+    }
+
+    auto newFuncOp = rewriter.create<spirv::FuncOp>(
+        funcOp.getLoc(), funcOp.getName(),
+        rewriter.getFunctionType(signatureConverter.getConvertedTypes(),
+                                 llvm::None));
+    for (const auto &namedAttr : funcOp.getAttrs()) {
+      if (namedAttr.first == impl::getTypeAttrName() ||
+          namedAttr.first == SymbolTable::getSymbolAttrName())
+        continue;
+      newFuncOp.setAttr(namedAttr.first, namedAttr.second);
+    }
+    rewriter.inlineRegionBefore(funcOp.getBody(), newFuncOp.getBody(),
+                                newFuncOp.end());
+    rewriter.applySignatureConversion(&newFuncOp.getBody(), signatureConverter);
+    rewriter.eraseOp(funcOp);
+
+    SmallVector<Attribute, 1> interfaceVars;
+    rewriter.create<spirv::EntryPointOp>(funcOp.getLoc(),
+                                         spirv::ExecutionModel::Kernel,
+                                         newFuncOp, interfaceVars);
+
+    return success();
+  }
+};
+
+class ComputeModuleLowering : public SPIRVOpLowering<compute::ModuleOp> {
+public:
+  using SPIRVOpLowering<compute::ModuleOp>::SPIRVOpLowering;
+
+  LogicalResult
+  matchAndRewrite(compute::ModuleOp moduleOp, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+class ComputeReturnLowering : public SPIRVOpLowering<compute::ReturnOp> {
+public:
+  using SPIRVOpLowering<compute::ReturnOp>::SPIRVOpLowering;
+
+  LogicalResult
+  matchAndRewrite(compute::ReturnOp moduleOp, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+class ComputeToOpenCLSPIRVPass
+    : public PassWrapper<ComputeToOpenCLSPIRVPass, OperationPass<ModuleOp>> {
+public:
+  void runOnOperation() override;
+};
+} // namespace
+
+LogicalResult ComputeReturnLowering::matchAndRewrite(
+    compute::ReturnOp returnOp, ArrayRef<Value> operands,
+    ConversionPatternRewriter &rewriter) const {
+
+  // todo adapt to use ReturnValue when compute dialect gets support for return
+
+  rewriter.replaceOpWithNewOp<spirv::ReturnOp>(returnOp);
+
+  return success();
+}
+
+void ComputeToOpenCLSPIRVPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  ModuleOp module = getOperation();
+
+  SmallVector<Operation *, 1> computeModules;
+  OpBuilder builder(context);
+
+  module.walk([&builder, &computeModules](compute::ModuleOp moduleOp) {
+    builder.setInsertionPoint(moduleOp.getOperation());
+    computeModules.push_back(builder.clone(*moduleOp.getOperation()));
+  });
+
+  // fixme spir-v version and capabilities must be inferred from module.
+  auto triple = spirv::VerCapExtAttr::get(
+      spirv::Version::V_1_0, {spirv::Capability::Kernel},
+      ArrayRef<spirv::Extension>(), context);
+  auto targetAttr = spirv::TargetEnvAttr::get(
+      triple, spirv::getDefaultResourceLimits(context));
+
+  std::unique_ptr<ConversionTarget> target =
+      spirv::SPIRVConversionTarget::get(targetAttr);
+
+  SPIRVTypeConverter typeConverter(targetAttr);
+  OwningRewritePatternList patterns;
+  // Structured control flow
+  populateGPUToSPIRVPatterns(context, typeConverter, patterns);
+  populateStandardToSPIRVPatterns(context, typeConverter, patterns);
+  populateComputeToOpenCLSPIRVPatterns(context, typeConverter, patterns);
+
+  if (failed(applyFullConversion(computeModules, *target, patterns,
+                                 &typeConverter))) {
+    return signalPassFailure();
+  }
+}
+
+LogicalResult ComputeModuleLowering::matchAndRewrite(
+    compute::ModuleOp moduleOp, ArrayRef<Value> operands,
+    ConversionPatternRewriter &rewriter) const {
+  auto spvModule = rewriter.create<spirv::ModuleOp>(
+      moduleOp.getLoc(), spirv::AddressingModel::Logical,
+      spirv::MemoryModel::OpenCL);
+
+  // fixme for prototyping only. This info must be obtained from module.
+  auto triple = spirv::VerCapExtAttr::get(
+      spirv::Version::V_1_0, {spirv::Capability::Kernel},
+      ArrayRef<spirv::Extension>(), moduleOp.getContext());
+  spvModule.vce_tripleAttr(triple);
+
+  // Move the region from the module op into the SPIR-V module.
+  Region &spvModuleRegion = spvModule.body();
+  rewriter.inlineRegionBefore(moduleOp.body(), spvModuleRegion,
+                              spvModuleRegion.begin());
+  // The spv.module build method adds a block with a terminator. Remove that
+  // block. The terminator of the module op in the remaining block will be
+  // legalized later.
+  spvModuleRegion.back().erase();
+  rewriter.eraseOp(moduleOp);
+  return success();
+}
+
+namespace {
+#include "ComputeToSPIRV.cpp.inc"
+}
+
+namespace mlir {
+
+void populateComputeToOpenCLSPIRVPatterns(MLIRContext *context,
+                                          SPIRVTypeConverter &typeConverter,
+                                          OwningRewritePatternList &patterns) {
+  populateWithGenerated(context, &patterns);
+  patterns.insert<ComputeModuleLowering, ComputeFuncOpLowering,
+                  ComputeReturnLowering>(context, typeConverter);
+}
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertComputeToOpenCLSPIRVPass() {
+  return std::make_unique<ComputeToOpenCLSPIRVPass>();
+}
+} // namespace mlir

--- a/utils/dialects/lib/Conversion/ComputeToSPIRV/ComputeToSPIRV.td
+++ b/utils/dialects/lib/Conversion/ComputeToSPIRV/ComputeToSPIRV.td
@@ -1,0 +1,9 @@
+#ifndef CONVERT_COMPUTE_TO_SPIRV
+#define CONVERT_COMPUTE_TO_SPIRV
+
+include "Compute/ComputeOps.td"
+include "mlir/Dialect/SPIRV/SPIRVStructureOps.td"
+
+def : Pat<(Compute_ModuleEndOp), (SPV_ModuleEndOp)>;
+
+#endif // CONVERT_COMPUTE_TO_SPIRV


### PR DESCRIPTION
Compute dialect is aimed to be a more powerful and robust replacement to MLIR's GPU dialect. This is the first iteration on Compute design. The roadmap includes support for host launch operations, lowering to PTX and ROCDl, subgroups support.